### PR TITLE
Treat out-of-order Slack preview edits as new messages

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1906,8 +1906,8 @@ impl Slack {
         user: Option<String>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
-        is_edit: bool,
-        irc_flag: bool,
+        mut is_edit: bool,
+        mut irc_flag: bool,
     ) -> anyhow::Result<()> {
         let has_message = message.is_some();
         let has_attachments = attachments.is_some();
@@ -1915,12 +1915,16 @@ impl Slack {
             Some(ts) => Some((Some(ts.clone()), None)),
             None => None,
         };
-        let pipo_id = match ts {
-            Some(ts) => match self.select_id_from_messages(&ts).await {
-                Some(id) => id,
-                None => self.insert_into_messages_table(&ts).await?,
-            },
-            None => return Err(anyhow!("Message has no timestamp.")),
+        let ts = ts.ok_or_else(|| anyhow!("Message has no timestamp."))?;
+        let pipo_id = match self.select_id_from_messages(&ts).await {
+            Some(id) => id,
+            None => {
+                if is_edit {
+                    is_edit = false;
+                    irc_flag = false;
+                }
+                self.insert_into_messages_table(&ts).await?
+            }
         };
         let user = self
             .get_user_info(&user.ok_or_else(|| anyhow!("No user ID in message."))?)


### PR DESCRIPTION
### Motivation
- Slack delivers URL previews as `message_changed` edits which can arrive before the original `message` event and cause the original message text to be dropped. 
- The existing `pipo_id` resolution registered timestamps for the preview-edit path and then caused the later original to be treated as a duplicate and dropped. 
- The intent is to ensure the first-seen event (often the preview) is relayed as a normal message so live UX is preserved even if full history is incomplete.

### Description
- Updated `Slack::handle_message` in `src/slack.rs` to require `ts` via `ts.ok_or_else(|| anyhow!("Message has no timestamp."))?` before resolving the stored message id. 
- Changed the `is_edit` and `irc_flag` parameters to be `mut` so they can be modified when necessary. 
- If no existing message id is found and the event is an edit, the code now downgrades it by setting `is_edit = false` and `irc_flag = false` before inserting the timestamp mapping and continuing as a fresh message.

### Testing
- Ran `cargo check -q` to verify the code compiles; the run produced warnings but completed in this environment. 
- Attempted `cargo test -q --no-run` and `cargo test -q`, but the test invocations timed out in this environment (commands produced long compiler output and were terminated with a timeout). 
- No unit-test failures were observed before the timeout, and the diff compiles under `cargo check` in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b346420c6c8331af9043e850955aaf)