### PR TITLE
Deduplicate Slack Socket Mode retries using event_id

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     sync::{Arc, Mutex},
 };
 
@@ -44,6 +44,7 @@ pub(crate) struct Slack {
     channel_map: HashMap<String, String>,
     id_map: HashMap<String, String>,
     users: HashMap<String, User>,
+    seen_event_ids: VecDeque<String>,
 }
 
 struct WebSocket {
@@ -92,6 +93,7 @@ impl Slack {
             channel_map: HashMap::new(),
             id_map: HashMap::new(),
             users: HashMap::new(),
+            seen_event_ids: VecDeque::with_capacity(50),
         })
     }
 
@@ -1218,11 +1220,31 @@ impl Slack {
             Response::EventsApi {
                 envelope_id,
                 accepts_response_payload: _,
-                retry_attempt: _,
+                retry_attempt,
                 retry_reason: _,
                 payload,
             } => {
                 self.acknowledge(&envelope_id).await?;
+
+                if retry_attempt > 0 {
+                    let event_id = match &payload {
+                        EventPayload::EventCallback { event_id, .. } => Some(event_id.clone()),
+                        EventPayload::UrlVerification { .. } => None,
+                    };
+
+                    if let Some(event_id) = event_id {
+                        if self.seen_event_ids.contains(&event_id) {
+                            return Ok(());
+                        }
+
+                        if self.seen_event_ids.len() == 50 {
+                            self.seen_event_ids.pop_front();
+                        }
+
+                        self.seen_event_ids.push_back(event_id);
+                    }
+                }
+
                 self.handle_event_payload(payload).await
             }
             Response::Hello {


### PR DESCRIPTION
### Motivation
- Slack Socket Mode can retransmit events when an ACK is not received, which allowed duplicate processing of the same `event_id` when retries arrived.  
- Add a lightweight in-memory deduplication for recent `event_id`s and implement Option A so dedupe logic is co-located with the ACK handling.

### Description
- Add a `seen_event_ids: VecDeque<String>` field to `Slack` and initialize it with `VecDeque::with_capacity(50)` in `Slack::new` to act as a bounded recent-event cache.  
- In `handle_response` keep `retry_attempt` from `Response::EventsApi`, ACK the `envelope_id` immediately, and for `retry_attempt > 0` extract the `event_id` from the `EventPayload::EventCallback` before dispatch.  
- If the `event_id` is already present in `seen_event_ids` return early (ACKed) without dispatch; otherwise evict oldest entry when at capacity and push the new `event_id`, then call `handle_event_payload` unchanged.

### Testing
- Ran `cargo test -q` and it completed successfully (no tests were executed in this workspace).  
- The project compiled during the test run with warnings only and no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b35c7dcd6483319c9b4cbbdb777e60)