### PR TITLE
Add canonical line-delimited NDJSON protocol fixtures

### DIFF
--- a/schema/fixtures/README.md
+++ b/schema/fixtures/README.md
@@ -1,0 +1,12 @@
+# Protocol fixture set (line-delimited JSON)
+
+Each `*.ndjson` file in this directory is canonical test data for a specific frame shape.
+All timestamps are RFC3339 UTC with millisecond precision (`...000Z`).
+
+- `ready.ndjson`: outbound ready frame.
+- `message.ndjson`: outbound message frames including nullable and omitted `pipo_id` variants.
+- `inject_message.ndjson`: inbound inject_message frames with required `pipo_id` and `origin_transport`.
+- `lifecycle.ndjson`: lifecycle/status frames (`health`, `warn`, `fatal`, `shutdown`, `health_check`).
+- `reload_config_inbound.ndjson`: reserved inbound frame example.
+- `reload_config_expected_warn.ndjson`: expected warn response (`unimplemented`).
+- `malformed_lines.ndjson`: intentionally malformed lines for negative tests.

--- a/schema/fixtures/inject_message.ndjson
+++ b/schema/fixtures/inject_message.ndjson
@@ -1,0 +1,1 @@
+{"type":"inject_message","timestamp":"2026-01-15T08:30:03.000Z","pipo_id":"pipo-123","origin_transport":"stdin","bus":"events","payload":{"kind":"command","value":"refresh"}}

--- a/schema/fixtures/lifecycle.ndjson
+++ b/schema/fixtures/lifecycle.ndjson
@@ -1,0 +1,5 @@
+{"type":"health","timestamp":"2026-01-15T08:30:04.000Z","status":"ok"}
+{"type":"warn","timestamp":"2026-01-15T08:30:05.000Z","code":"deprecated_field","message":"field x is deprecated"}
+{"type":"fatal","timestamp":"2026-01-15T08:30:06.000Z","code":"startup_failed","message":"unable to bind socket"}
+{"type":"shutdown","timestamp":"2026-01-15T08:30:07.000Z","reason":"signal"}
+{"type":"health_check","timestamp":"2026-01-15T08:30:08.000Z","probe_id":"hc-001"}

--- a/schema/fixtures/malformed_lines.ndjson
+++ b/schema/fixtures/malformed_lines.ndjson
@@ -1,0 +1,4 @@
+{"type":"ready","timestamp":"2026-01-15T08:30:00.000Z","version":"1.0.0"
+not-json-at-all
+{"type":"message","timestamp":"2026-01-15T08:30:01Z","bus":"events","payload":{}}
+{"type":"inject_message","timestamp":"2026-01-15T08:30:03.000Z","origin_transport":"stdin","bus":"events","payload":{}}

--- a/schema/fixtures/message.ndjson
+++ b/schema/fixtures/message.ndjson
@@ -1,0 +1,2 @@
+{"type":"message","timestamp":"2026-01-15T08:30:01.000Z","bus":"events","pipo_id":null,"payload":{"kind":"status","value":"ok"}}
+{"type":"message","timestamp":"2026-01-15T08:30:02.000Z","bus":"events","payload":{"kind":"status","value":"ok"}}

--- a/schema/fixtures/ready.ndjson
+++ b/schema/fixtures/ready.ndjson
@@ -1,0 +1,1 @@
+{"type":"ready","timestamp":"2026-01-15T08:30:00.000Z","version":"1.0.0","transport":"bus"}

--- a/schema/fixtures/reload_config_expected_warn.ndjson
+++ b/schema/fixtures/reload_config_expected_warn.ndjson
@@ -1,0 +1,1 @@
+{"type":"warn","timestamp":"2026-01-15T08:30:10.000Z","code":"unimplemented","message":"reload_config is reserved but not implemented","request_id":"req-001"}

--- a/schema/fixtures/reload_config_inbound.ndjson
+++ b/schema/fixtures/reload_config_inbound.ndjson
@@ -1,0 +1,1 @@
+{"type":"reload_config","timestamp":"2026-01-15T08:30:09.000Z","request_id":"req-001"}


### PR DESCRIPTION
### Motivation
- Provide a canonical set of line-delimited JSON fixtures for protocol frames to standardize tests and documentation across runtimes. 
- Ensure timestamps use RFC3339 UTC with millisecond precision and include negative-test samples to exercise parsers. 

### Description
- Add `schema/fixtures/README.md` documenting fixture coverage and the required timestamp format (`...000Z`).
- Add `ready.ndjson` as an example outbound `ready` frame with timestamp and transport fields.
- Add `message.ndjson` demonstrating both nullable `pipo_id` and an omitted `pipo_id` variant.
- Add `inject_message.ndjson` showing inbound `inject_message` frames with required `pipo_id` and `origin_transport` fields.
- Add `lifecycle.ndjson` containing `health`, `warn`, `fatal`, `shutdown`, and `health_check` frames.
- Add `reload_config_inbound.ndjson` as the reserved inbound `reload_config` example and `reload_config_expected_warn.ndjson` with the expected `warn` response using `code: "unimplemented"`.
- Add `malformed_lines.ndjson` containing intentionally malformed lines (broken JSON, non-JSON line, a timestamp without millisecond precision, and an `inject_message` missing `pipo_id`) for negative tests.

### Testing
- Validated canonical fixture files with `jq -c .` via `for f in ...; do jq -c . "$f" >/dev/null || exit 1; done` which succeeded for all canonical fixtures. 
- Verified `malformed_lines.ndjson` fails JSON parsing with `jq`, producing a non-zero exit as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b49ac8bbb483318c9b973090097caf)