### PR TITLE
Add pipo-transport CLI, NDJSON protocol framing, and runtime event loop

### DIFF
--- a/native/transport_runtime/Cargo.lock
+++ b/native/transport_runtime/Cargo.lock
@@ -3,5 +3,345 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "transport_runtime"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/native/transport_runtime/Cargo.toml
+++ b/native/transport_runtime/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2021"
 [lib]
 path = "src/lib.rs"
 
+[[bin]]
+name = "pipo-transport"
+path = "src/main.rs"
+
 [dependencies]
+chrono = { version = "0.4", features = ["clock", "std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [workspace]

--- a/native/transport_runtime/src/lib.rs
+++ b/native/transport_runtime/src/lib.rs
@@ -1,16 +1,46 @@
-//! Minimal transport runtime placeholder crate.
+//! Transport runtime protocol primitives.
 
-/// Returns a stable placeholder protocol version string.
+pub mod protocol;
+
+/// Returns the supported protocol version string.
 pub fn protocol_version() -> &'static str {
-    "v0-placeholder"
+    protocol::SUPPORTED_PROTOCOL_VERSION
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitCode {
+    OrderlyShutdown = 0,
+    InvalidArgsOrConfig = 2,
+    ProtocolVersionIncompatible = 3,
+    TransportAuthFailure = 10,
+    TransportNetworkUnreachable = 11,
+    TransportFatal = 12,
+    InternalPanic = 20,
+}
+
+impl ExitCode {
+    pub fn as_i32(self) -> i32 {
+        self as i32
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::protocol_version;
+    use super::{protocol_version, ExitCode};
 
     #[test]
     fn protocol_version_is_stable() {
-        assert_eq!(protocol_version(), "v0-placeholder");
+        assert_eq!(protocol_version(), "v1");
+    }
+
+    #[test]
+    fn exit_codes_match_spec() {
+        assert_eq!(ExitCode::OrderlyShutdown.as_i32(), 0);
+        assert_eq!(ExitCode::InvalidArgsOrConfig.as_i32(), 2);
+        assert_eq!(ExitCode::ProtocolVersionIncompatible.as_i32(), 3);
+        assert_eq!(ExitCode::TransportAuthFailure.as_i32(), 10);
+        assert_eq!(ExitCode::TransportNetworkUnreachable.as_i32(), 11);
+        assert_eq!(ExitCode::TransportFatal.as_i32(), 12);
+        assert_eq!(ExitCode::InternalPanic.as_i32(), 20);
     }
 }

--- a/native/transport_runtime/src/main.rs
+++ b/native/transport_runtime/src/main.rs
@@ -1,0 +1,213 @@
+use std::fs;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use transport_runtime::protocol::{
+    encode_ndjson_frame, parse_ndjson_line, FrameMeta, InboundFrame, OutboundFrame,
+    SUPPORTED_PROTOCOL_VERSION,
+};
+use transport_runtime::ExitCode;
+
+#[derive(Debug)]
+struct Cli {
+    transport: String,
+    config: String,
+    instance_id: String,
+    protocol_version: String,
+}
+
+#[derive(Debug)]
+struct TransportEvent {
+    bus: String,
+    payload: serde_json::Value,
+}
+
+fn main() {
+    let code = std::panic::catch_unwind(run)
+        .unwrap_or(ExitCode::InternalPanic)
+        .as_i32();
+    process::exit(code);
+}
+
+fn run() -> ExitCode {
+    let cli = match parse_cli(std::env::args().skip(1)) {
+        Ok(cli) => cli,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::InvalidArgsOrConfig;
+        }
+    };
+
+    if cli.protocol_version != SUPPORTED_PROTOCOL_VERSION {
+        eprintln!(
+            "Protocol version mismatch: requested={}, supported={}",
+            cli.protocol_version, SUPPORTED_PROTOCOL_VERSION
+        );
+        return ExitCode::ProtocolVersionIncompatible;
+    }
+
+    let config_raw = match fs::read_to_string(&cli.config) {
+        Ok(raw) => raw,
+        Err(err) => {
+            eprintln!("Failed to read config: {err}");
+            return ExitCode::InvalidArgsOrConfig;
+        }
+    };
+
+    if serde_json::from_str::<serde_json::Value>(&config_raw).is_err() {
+        eprintln!("Config must be valid JSON");
+        return ExitCode::InvalidArgsOrConfig;
+    }
+
+    if let Some(exit) = simulate_transport_startup_failures(&config_raw) {
+        return exit;
+    }
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    let ready = OutboundFrame::Ready { meta: meta(&cli) };
+    if emit(&mut stdout, &ready).is_err() {
+        return ExitCode::TransportFatal;
+    }
+
+    let (stdin_tx, stdin_rx) = mpsc::channel::<String>();
+    let (transport_tx, transport_rx) = mpsc::channel::<TransportEvent>();
+
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stdin.lock());
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let _ = stdin_tx.send(line.trim_end().to_owned());
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    loop {
+        while let Ok(event) = transport_rx.try_recv() {
+            let frame = OutboundFrame::Message {
+                meta: meta(&cli),
+                bus: event.bus,
+                pipo_id: None,
+                payload: event.payload,
+            };
+            if emit(&mut stdout, &frame).is_err() {
+                return ExitCode::TransportFatal;
+            }
+        }
+
+        match stdin_rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(line) => {
+                if line.is_empty() {
+                    continue;
+                }
+                match parse_ndjson_line(&line) {
+                    Ok(InboundFrame::Shutdown) => return ExitCode::OrderlyShutdown,
+                    Ok(InboundFrame::HealthCheck) => {
+                        let frame = OutboundFrame::Health {
+                            meta: meta(&cli),
+                            status: "ok",
+                        };
+                        if emit(&mut stdout, &frame).is_err() {
+                            return ExitCode::TransportFatal;
+                        }
+                    }
+                    Ok(InboundFrame::InjectMessage {
+                        bus,
+                        pipo_id,
+                        origin_transport,
+                        payload,
+                    }) => {
+                        let _ = (pipo_id, origin_transport);
+                        if transport_tx.send(TransportEvent { bus, payload }).is_err() {
+                            return ExitCode::TransportFatal;
+                        }
+                    }
+                    Ok(InboundFrame::ReloadConfig) => {
+                        let frame = OutboundFrame::Warn {
+                            meta: meta(&cli),
+                            warn_type: "unimplemented",
+                            message: "reload_config is reserved and not implemented".to_owned(),
+                        };
+                        if emit(&mut stdout, &frame).is_err() {
+                            return ExitCode::TransportFatal;
+                        }
+                    }
+                    Err(err) => {
+                        let frame = OutboundFrame::Warn {
+                            meta: meta(&cli),
+                            warn_type: "invalid_frame",
+                            message: format!("Failed to parse inbound frame: {err}"),
+                        };
+                        if emit(&mut stdout, &frame).is_err() {
+                            return ExitCode::TransportFatal;
+                        }
+                    }
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => return ExitCode::OrderlyShutdown,
+        }
+    }
+}
+
+fn emit(stdout: &mut io::Stdout, frame: &OutboundFrame) -> io::Result<()> {
+    let encoded = encode_ndjson_frame(frame)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    stdout.write_all(encoded.as_bytes())?;
+    stdout.flush()
+}
+
+fn meta(cli: &Cli) -> FrameMeta {
+    FrameMeta::new(&cli.protocol_version, &cli.transport, &cli.instance_id)
+}
+
+fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli, String> {
+    let mut transport = None;
+    let mut config = None;
+    let mut instance_id = None;
+    let mut protocol_version = Some(SUPPORTED_PROTOCOL_VERSION.to_owned());
+
+    let mut iter = args.peekable();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--transport" => transport = iter.next(),
+            "--config" => config = iter.next(),
+            "--instance-id" => instance_id = iter.next(),
+            "--protocol-version" => protocol_version = iter.next(),
+            _ => return Err(format!("Unknown argument: {arg}")),
+        }
+    }
+
+    let transport = transport.ok_or("Missing required --transport".to_owned())?;
+    let config = config.ok_or("Missing required --config".to_owned())?;
+    let instance_id = instance_id.unwrap_or_else(|| format!("{}_0", transport));
+    let protocol_version = protocol_version.ok_or("Missing protocol version value".to_owned())?;
+
+    Ok(Cli {
+        transport,
+        config,
+        instance_id,
+        protocol_version,
+    })
+}
+
+fn simulate_transport_startup_failures(config_raw: &str) -> Option<ExitCode> {
+    let value: serde_json::Value = serde_json::from_str(config_raw).ok()?;
+    let startup = value.get("startup_failure")?.as_str()?;
+    match startup {
+        "auth" => Some(ExitCode::TransportAuthFailure),
+        "network" => Some(ExitCode::TransportNetworkUnreachable),
+        "fatal" => Some(ExitCode::TransportFatal),
+        _ => Some(ExitCode::TransportFatal),
+    }
+}

--- a/native/transport_runtime/src/protocol.rs
+++ b/native/transport_runtime/src/protocol.rs
@@ -1,0 +1,115 @@
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const SUPPORTED_PROTOCOL_VERSION: &str = "v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrameMeta {
+    pub protocol_version: String,
+    pub transport: String,
+    pub instance_id: String,
+    pub timestamp: String,
+}
+
+impl FrameMeta {
+    pub fn new(protocol_version: &str, transport: &str, instance_id: &str) -> Self {
+        Self {
+            protocol_version: protocol_version.to_owned(),
+            transport: transport.to_owned(),
+            instance_id: instance_id.to_owned(),
+            timestamp: utc_timestamp(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum InboundFrame {
+    #[serde(rename = "shutdown")]
+    Shutdown,
+    #[serde(rename = "inject_message")]
+    InjectMessage {
+        bus: String,
+        pipo_id: i64,
+        origin_transport: String,
+        payload: Value,
+    },
+    #[serde(rename = "health_check")]
+    HealthCheck,
+    #[serde(rename = "reload_config")]
+    ReloadConfig,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum OutboundFrame {
+    #[serde(rename = "ready")]
+    Ready {
+        #[serde(flatten)]
+        meta: FrameMeta,
+    },
+    #[serde(rename = "message")]
+    Message {
+        #[serde(flatten)]
+        meta: FrameMeta,
+        bus: String,
+        pipo_id: Option<i64>,
+        payload: Value,
+    },
+    #[serde(rename = "health")]
+    Health {
+        #[serde(flatten)]
+        meta: FrameMeta,
+        status: &'static str,
+    },
+    #[serde(rename = "warn")]
+    Warn {
+        #[serde(flatten)]
+        meta: FrameMeta,
+        warn_type: &'static str,
+        message: String,
+    },
+    #[serde(rename = "fatal")]
+    Fatal {
+        #[serde(flatten)]
+        meta: FrameMeta,
+        message: String,
+    },
+}
+
+pub fn parse_ndjson_line(line: &str) -> Result<InboundFrame, serde_json::Error> {
+    serde_json::from_str::<InboundFrame>(line)
+}
+
+pub fn encode_ndjson_frame(frame: &OutboundFrame) -> Result<String, serde_json::Error> {
+    let mut out = serde_json::to_string(frame)?;
+    out.push('\n');
+    Ok(out)
+}
+
+pub fn utc_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ndjson_encode_ends_with_newline() {
+        let frame = OutboundFrame::Health {
+            meta: FrameMeta::new(SUPPORTED_PROTOCOL_VERSION, "slack", "slack_0"),
+            status: "ok",
+        };
+        let encoded = encode_ndjson_frame(&frame).expect("encode");
+        assert!(encoded.ends_with('\n'));
+    }
+
+    #[test]
+    fn utc_timestamp_uses_zulu_with_millis() {
+        let ts = utc_timestamp();
+        assert!(ts.ends_with('Z'));
+        assert!(ts.contains('.'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a stdio-backed transport worker that implements the runtime handshake and message framing required by the protocol spec (ready handshake, NDJSON frames, RFC3339 UTC timestamps with millisecond precision). 
- Enforce protocol-version compatibility and map startup/termination conditions to the supervisor-aware exit codes from the spec. 
- Reserve `reload_config` in the protocol and respond with an `unimplemented` `warn` frame without stopping the worker.

### Description
- Added a `pipo-transport` binary entry in `Cargo.toml` and a new `src/main.rs` implementing CLI parsing for required `--transport`/`--config` and optional `--instance-id`/`--protocol-version`, startup validation, `ready` emission, and the main event loop that processes stdin frames and transport events. 
- Introduced a `protocol` module (`src/protocol.rs`) that implements NDJSON parse/encode helpers, typed inbound (`shutdown`, `inject_message`, `health_check`, `reload_config`) and outbound (`ready`, `message`, `health`, `warn`, `fatal`) frame enums, and `FrameMeta` with UTC RFC3339 millisecond timestamps. 
- Implemented an `ExitCode` enum in `lib.rs` matching the spec exit codes (0, 2, 3, 10, 11, 12, 20) and wired panic handling to return `InternalPanic` on unwind. 
- Implemented handlers in the event loop for `shutdown` (orderly exit), `inject_message` (enqueue and emit `message`), `health_check` (emit `health`), and reserved `reload_config` (emit `warn` with `unimplemented` and continue). 

### Testing
- Ran `cargo fmt` in `native/transport_runtime` successfully. 
- Ran `cargo test` in `native/transport_runtime` and all tests passed (`protocol` unit tests and crate smoke test completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b49b01fd3c833185f8d1892d5ec494)