### PR TITLE
Implement pipo supervisor router/worker runtime behavior

### DIFF
--- a/apps/pipo_supervisor/lib/pipo_supervisor/application.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/application.ex
@@ -5,9 +5,31 @@ defmodule PipoSupervisor.Application do
 
   @impl true
   def start(_type, _args) do
-    children = []
+    opts = Application.get_env(:pipo_supervisor, :supervisor, [])
 
-    opts = [strategy: :one_for_one, name: PipoSupervisor.Supervisor]
-    Supervisor.start_link(children, opts)
+    case PipoSupervisor.Supervisor.start_link(opts) do
+      {:ok, _pid} = ok ->
+        maybe_require_all_ready(opts)
+        ok
+
+      other ->
+        other
+    end
+  end
+
+  defp maybe_require_all_ready(opts) do
+    if Keyword.get(opts, :require_all_ready, false) do
+      workers = Keyword.get(opts, :workers, Application.get_env(:pipo_supervisor, :workers, []))
+      timeout = Keyword.get(opts, :require_all_ready_timeout_ms, 5_000)
+
+      Enum.each(workers, fn worker_id ->
+        worker = GenServer.whereis(PipoSupervisor.PortWorker.via_name(worker_id))
+
+        case worker && GenServer.call(worker, :status, timeout) do
+          :ready -> :ok
+          status -> raise "worker #{inspect(worker_id)} not ready: #{inspect(status)}"
+        end
+      end)
+    end
   end
 end

--- a/apps/pipo_supervisor/lib/pipo_supervisor/ndjson.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/ndjson.ex
@@ -1,0 +1,52 @@
+defmodule PipoSupervisor.NDJSON do
+  @moduledoc false
+
+  def decode_line(line) when is_binary(line) do
+    cond do
+      String.contains?(line, "\"event\":\"ready\"") or
+          String.contains?(line, "\"event\": \"ready\"") ->
+        {:ok, %{"event" => "ready"}}
+
+      true ->
+        with [_, bus] <- Regex.run(~r/"bus"\s*:\s*"([^"]+)"/, line),
+             [_, payload_raw] <-
+               Regex.run(
+                 ~r/"payload"\s*:\s*(\{.*\}|\[.*\]|".*"|true|false|null|-?\d+(?:\.\d+)?)/,
+                 line
+               ) do
+          {:ok, %{"event" => "publish", "bus" => bus, "payload" => decode_payload(payload_raw)}}
+        else
+          _ -> {:error, :invalid_json}
+        end
+    end
+  end
+
+  def encode_frame(map) when is_map(map) do
+    "{" <>
+      (map
+       |> Enum.map(fn {k, v} -> "\"#{k}\":" <> encode_value(v) end)
+       |> Enum.join(",")) <> "}"
+  end
+
+  defp decode_payload("{}"), do: %{}
+  defp decode_payload("[]"), do: []
+  defp decode_payload("true"), do: true
+  defp decode_payload("false"), do: false
+  defp decode_payload("null"), do: nil
+
+  defp decode_payload(payload) do
+    case Integer.parse(payload) do
+      {int, ""} -> int
+      _ -> String.trim(payload, "\"")
+    end
+  end
+
+  defp encode_value(value) when is_binary(value), do: "\"#{value}\""
+  defp encode_value(value) when is_integer(value), do: Integer.to_string(value)
+  defp encode_value(value) when is_boolean(value), do: if(value, do: "true", else: "false")
+  defp encode_value(nil), do: "null"
+  defp encode_value(value) when is_map(value), do: encode_frame(value)
+
+  defp encode_value(value) when is_list(value),
+    do: "[" <> Enum.map_join(value, ",", &encode_value/1) <> "]"
+end

--- a/apps/pipo_supervisor/lib/pipo_supervisor/port_worker.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/port_worker.ex
@@ -1,0 +1,204 @@
+defmodule PipoSupervisor.PortWorker do
+  @moduledoc """
+  Bridges an external `pipo-transport` process and the Router.
+  """
+
+  use GenServer
+  require Logger
+
+  @default_ready_timeout_ms 5_000
+  @default_shutdown_timeout_ms 1_000
+  @default_backoff_ms 100
+  @default_jitter_ms 50
+
+  defstruct id: nil,
+            router: PipoSupervisor.Router,
+            transport_path: nil,
+            port: nil,
+            status: :starting,
+            ready_timeout_ms: @default_ready_timeout_ms,
+            shutdown_timeout_ms: @default_shutdown_timeout_ms,
+            ready_timer: nil,
+            backoff_ms: @default_backoff_ms,
+            jitter_ms: @default_jitter_ms
+
+  def start_link(opts) do
+    id = Keyword.fetch!(opts, :id)
+    name = Keyword.get(opts, :name, via_name(id))
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def via_name(id), do: {:global, {__MODULE__, id}}
+
+  @impl true
+  def init(opts) do
+    config = Application.get_env(:pipo_supervisor, :port_worker, [])
+    merged = Keyword.merge(config, opts)
+
+    state = %__MODULE__{
+      id: Keyword.fetch!(merged, :id),
+      router: Keyword.get(merged, :router, PipoSupervisor.Router),
+      transport_path: resolve_transport_path(Keyword.get(merged, :transport_path)),
+      ready_timeout_ms: Keyword.get(merged, :ready_timeout_ms, @default_ready_timeout_ms),
+      shutdown_timeout_ms:
+        Keyword.get(merged, :shutdown_timeout_ms, @default_shutdown_timeout_ms),
+      backoff_ms: Keyword.get(merged, :backoff_ms, @default_backoff_ms),
+      jitter_ms: Keyword.get(merged, :jitter_ms, @default_jitter_ms)
+    }
+
+    backoff = state.backoff_ms + :rand.uniform(max(state.jitter_ms, 1)) - 1
+    Process.send_after(self(), :boot_transport, backoff)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:boot_transport, state) do
+    case launch_port(state.transport_path) do
+      {:ok, port} ->
+        ready_timer = Process.send_after(self(), :ready_timeout, state.ready_timeout_ms)
+        maybe_register_worker(state.router, state.id)
+        {:noreply, %{state | port: port, ready_timer: ready_timer, status: :starting}}
+
+      {:error, reason} ->
+        Logger.error("worker #{inspect(state.id)} failed to launch transport: #{inspect(reason)}")
+        {:stop, reason, %{state | status: :stopped}}
+    end
+  end
+
+  def handle_info(:ready_timeout, state = %{status: :starting}) do
+    Logger.warning("worker #{inspect(state.id)} did not become ready before timeout")
+    {:noreply, %{state | status: :degraded, ready_timer: nil}}
+  end
+
+  def handle_info({port, {:data, {:eol, line}}}, %{port: port} = state) do
+    next_state = handle_transport_line(String.trim(line), state)
+    {:noreply, next_state}
+  end
+
+  def handle_info({port, {:data, {:noeol, line}}}, %{port: port} = state) do
+    next_state = handle_transport_line(String.trim(line), state)
+    {:noreply, next_state}
+  end
+
+  def handle_info({port, {:exit_status, _status}}, %{port: port} = state) do
+    {:stop, :transport_exited, %{state | status: :stopped, port: nil}}
+  end
+
+  @impl true
+  def handle_call({:deliver, frame}, _from, state) do
+    case state.port do
+      nil ->
+        {:reply, {:error, :no_port}, state}
+
+      port ->
+        payload = PipoSupervisor.NDJSON.encode_frame(frame)
+        Port.command(port, payload <> "\n")
+        {:reply, :ok, state}
+    end
+  end
+
+  def handle_call(:status, _from, state), do: {:reply, state.status, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    graceful_stop_port(state)
+    :ok
+  end
+
+  defp handle_transport_line("", state), do: state
+
+  defp handle_transport_line(line, state) do
+    with {:ok, decoded} <- PipoSupervisor.NDJSON.decode_line(line) do
+      process_frame(decoded, state)
+    else
+      _ ->
+        Logger.warning(
+          "worker #{inspect(state.id)} received invalid NDJSON frame: #{inspect(line)}"
+        )
+
+        state
+    end
+  end
+
+  defp process_frame(%{"event" => "ready"}, state) do
+    if state.ready_timer, do: Process.cancel_timer(state.ready_timer)
+    %{state | status: :ready, ready_timer: nil}
+  end
+
+  defp process_frame(%{"event" => "publish", "bus" => bus, "payload" => payload}, state) do
+    case Process.whereis(state.router) do
+      nil ->
+        Logger.warning("router unavailable; dropping publish from #{inspect(state.id)}")
+        state
+
+      _pid ->
+        PipoSupervisor.Router.publish(state.router, state.id, bus, payload)
+        state
+    end
+  end
+
+  defp process_frame(_frame, state), do: state
+
+  defp maybe_register_worker(router, id) do
+    case GenServer.whereis(router) do
+      nil ->
+        Logger.warning("router unavailable during worker registration for #{inspect(id)}")
+        :ok
+
+      _ ->
+        _ = PipoSupervisor.Router.register_worker(router, id, self())
+        :ok
+    end
+  end
+
+  defp graceful_stop_port(%{port: nil}), do: :ok
+
+  defp graceful_stop_port(state) do
+    shutdown_frame = PipoSupervisor.NDJSON.encode_frame(%{"event" => "shutdown"}) <> "\n"
+    Port.command(state.port, shutdown_frame)
+
+    receive do
+      {port, {:exit_status, _status}} when port == state.port ->
+        :ok
+    after
+      state.shutdown_timeout_ms ->
+        Port.close(state.port)
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp launch_port(nil), do: {:error, :missing_transport_path}
+
+  defp launch_port(path) do
+    if File.exists?(path) do
+      {:ok,
+       Port.open({:spawn_executable, path}, [
+         :binary,
+         {:line, 65_536},
+         :exit_status,
+         :use_stdio,
+         :stderr_to_stdout
+       ])}
+    else
+      {:error, :enoent}
+    end
+  end
+
+  defp resolve_transport_path(nil) do
+    env_path = System.get_env("PIPO_TRANSPORT_PATH")
+
+    release_relative =
+      Application.app_dir(:pipo_supervisor, "../../../native/pipo-transport")
+      |> Path.expand()
+
+    bundled = Application.app_dir(:pipo_supervisor, "priv/pipo-transport")
+
+    [env_path, release_relative, bundled]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.find(&File.exists?/1)
+  end
+
+  defp resolve_transport_path(path), do: path
+end

--- a/apps/pipo_supervisor/lib/pipo_supervisor/router.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/router.ex
@@ -1,0 +1,151 @@
+defmodule PipoSupervisor.Router do
+  @moduledoc """
+  Routes publish events between port workers based on bus subscriptions.
+  """
+
+  use GenServer
+  require Logger
+
+  @default_call_timeout_ms 1_000
+  @default_drop_threshold 10
+
+  defstruct routing_table: %{},
+            worker_pids: %{},
+            worker_health: %{},
+            next_pipo_id: 1,
+            call_timeout_ms: @default_call_timeout_ms,
+            drop_threshold: @default_drop_threshold,
+            notify_pid: nil
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def register_worker(router \\ __MODULE__, worker_id, pid) do
+    GenServer.call(router, {:register_worker, worker_id, pid})
+  end
+
+  def publish(router \\ __MODULE__, origin_worker_id, bus, payload) do
+    GenServer.cast(router, {:publish, origin_worker_id, bus, payload})
+  end
+
+  @impl true
+  def init(opts) do
+    config = Application.get_env(:pipo_supervisor, :router, [])
+    merged = Keyword.merge(config, opts)
+
+    state = %__MODULE__{
+      routing_table: build_routing_table(Keyword.get(merged, :channel_mapping, %{})),
+      call_timeout_ms: Keyword.get(merged, :call_timeout_ms, @default_call_timeout_ms),
+      drop_threshold: Keyword.get(merged, :drop_threshold, @default_drop_threshold),
+      notify_pid: Keyword.get(merged, :notify_pid)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call({:register_worker, worker_id, pid}, _from, state) do
+    monitor_ref = Process.monitor(pid)
+
+    worker_pids = Map.put(state.worker_pids, worker_id, {pid, monitor_ref})
+    worker_health = Map.put_new(state.worker_health, worker_id, %{degraded?: false, drops: 0})
+
+    {:reply, :ok, %{state | worker_pids: worker_pids, worker_health: worker_health}}
+  end
+
+  def handle_call({:deliver, _frame}, _from, state) do
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast({:publish, origin_worker_id, bus, payload}, state) do
+    recipient_ids =
+      state.routing_table
+      |> Map.get(bus, MapSet.new())
+      |> MapSet.delete(origin_worker_id)
+      |> MapSet.to_list()
+
+    pipo_id = state.next_pipo_id
+
+    frame = %{"event" => "deliver", "pipo_id" => pipo_id, "bus" => bus, "payload" => payload}
+
+    next_state =
+      Enum.reduce(recipient_ids, %{state | next_pipo_id: pipo_id + 1}, fn worker_id, acc ->
+        deliver_to_worker(acc, worker_id, frame)
+      end)
+
+    {:noreply, next_state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    worker_pids =
+      state.worker_pids
+      |> Enum.reject(fn {_worker_id, {_pid, mref}} -> mref == ref end)
+      |> Map.new()
+
+    {:noreply, %{state | worker_pids: worker_pids}}
+  end
+
+  defp deliver_to_worker(state, worker_id, frame) do
+    case Map.get(state.worker_pids, worker_id) do
+      {pid, _ref} ->
+        do_deliver(state, worker_id, pid, frame)
+
+      nil ->
+        state
+    end
+  end
+
+  defp do_deliver(state, worker_id, pid, frame) do
+    try do
+      case GenServer.call(pid, {:deliver, frame}, state.call_timeout_ms) do
+        :ok ->
+          put_health(state, worker_id, %{degraded?: false, drops: 0})
+
+        _ ->
+          increment_drop(state, worker_id, :unexpected_response)
+      end
+    catch
+      :exit, {:timeout, _} ->
+        Logger.warning("router timed out delivering to #{inspect(worker_id)}")
+        increment_drop(state, worker_id, :timeout)
+
+      :exit, reason ->
+        Logger.warning("router failed delivering to #{inspect(worker_id)}: #{inspect(reason)}")
+        increment_drop(state, worker_id, :exit)
+    end
+  end
+
+  defp put_health(state, worker_id, health) do
+    %{state | worker_health: Map.put(state.worker_health, worker_id, health)}
+  end
+
+  defp increment_drop(state, worker_id, reason) do
+    health = Map.get(state.worker_health, worker_id, %{degraded?: false, drops: 0})
+    drops = health.drops + 1
+    degraded = %{health | degraded?: true, drops: drops}
+
+    maybe_notify_degraded(state.notify_pid, worker_id, drops, state.drop_threshold, reason)
+
+    put_health(state, worker_id, degraded)
+  end
+
+  defp maybe_notify_degraded(nil, _worker_id, _drops, _threshold, _reason), do: :ok
+
+  defp maybe_notify_degraded(pid, worker_id, drops, threshold, reason) when drops >= threshold do
+    send(pid, {:worker_degraded, worker_id, drops, reason})
+  end
+
+  defp maybe_notify_degraded(_pid, _worker_id, _drops, _threshold, _reason), do: :ok
+
+  defp build_routing_table(channel_mapping) when is_map(channel_mapping) do
+    Enum.reduce(channel_mapping, %{}, fn {worker_id, busses}, acc ->
+      Enum.reduce(List.wrap(busses), acc, fn bus, inner ->
+        Map.update(inner, bus, MapSet.new([worker_id]), &MapSet.put(&1, worker_id))
+      end)
+    end)
+  end
+end

--- a/apps/pipo_supervisor/lib/pipo_supervisor/supervisor.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/supervisor.ex
@@ -1,0 +1,40 @@
+defmodule PipoSupervisor.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    workers = Keyword.get(opts, :workers, Application.get_env(:pipo_supervisor, :workers, []))
+    router_opts = Keyword.get(opts, :router, [])
+
+    children = [
+      {PipoSupervisor.Router, router_opts}
+      | Enum.map(workers, fn worker_id ->
+          %{
+            id: {:port_worker, worker_id},
+            start: {PipoSupervisor.PortWorker, :start_link, [[id: worker_id]]},
+            restart: :permanent,
+            shutdown: 2_000,
+            type: :worker
+          }
+        end)
+    ]
+
+    max_restarts =
+      Keyword.get(opts, :max_restarts, Application.get_env(:pipo_supervisor, :max_restarts, 3))
+
+    max_seconds =
+      Keyword.get(opts, :max_seconds, Application.get_env(:pipo_supervisor, :max_seconds, 10))
+
+    Supervisor.init(children,
+      strategy: :one_for_one,
+      max_restarts: max_restarts,
+      max_seconds: max_seconds
+    )
+  end
+end

--- a/apps/pipo_supervisor/mix.exs
+++ b/apps/pipo_supervisor/mix.exs
@@ -7,7 +7,7 @@ defmodule PipoSupervisor.MixProject do
       version: "0.1.0",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
-      deps: []
+      deps: deps()
     ]
   end
 
@@ -16,5 +16,9 @@ defmodule PipoSupervisor.MixProject do
       extra_applications: [:logger],
       mod: {PipoSupervisor.Application, []}
     ]
+  end
+
+  defp deps do
+    []
   end
 end

--- a/apps/pipo_supervisor/test/pipo_supervisor_test.exs
+++ b/apps/pipo_supervisor/test/pipo_supervisor_test.exs
@@ -1,7 +1,71 @@
-defmodule PipoSupervisorTest do
-  use ExUnit.Case, async: true
+defmodule PipoSupervisor.RouterTest do
+  use ExUnit.Case, async: false
 
-  test "returns status" do
-    assert :ok == PipoSupervisor.status()
+  defmodule TestWorker do
+    use GenServer
+
+    def start_link(test_pid, behavior \\ :ok) do
+      GenServer.start_link(__MODULE__, {test_pid, behavior})
+    end
+
+    def init({test_pid, behavior}), do: {:ok, %{test_pid: test_pid, behavior: behavior}}
+
+    def handle_call({:deliver, frame}, _from, %{behavior: :ok} = state) do
+      send(state.test_pid, {:delivered, self(), frame})
+      {:reply, :ok, state}
+    end
+
+    def handle_call({:deliver, _frame}, _from, %{behavior: :sleep} = state) do
+      Process.sleep(100)
+      {:reply, :ok, state}
+    end
+  end
+
+  test "builds routing table by inverting channel mapping and removes origin from fanout" do
+    {:ok, router} =
+      start_supervised(
+        {PipoSupervisor.Router,
+         name: :router_test_1,
+         channel_mapping: %{
+           worker_a: ["alpha", "beta"],
+           worker_b: ["alpha"]
+         }}
+      )
+
+    {:ok, worker_a} = TestWorker.start_link(self())
+    {:ok, worker_b} = TestWorker.start_link(self())
+
+    assert :ok = PipoSupervisor.Router.register_worker(router, :worker_a, worker_a)
+    assert :ok = PipoSupervisor.Router.register_worker(router, :worker_b, worker_b)
+
+    PipoSupervisor.Router.publish(router, :worker_a, "alpha", %{"x" => 1})
+
+    assert_receive {:delivered, ^worker_b,
+                    %{"bus" => "alpha", "payload" => %{"x" => 1}, "pipo_id" => 1}},
+                   500
+
+    refute_receive {:delivered, ^worker_a, _}, 100
+  end
+
+  test "times out deliveries, marks degraded and notifies at threshold" do
+    {:ok, router} =
+      start_supervised(
+        {PipoSupervisor.Router,
+         name: :router_test_2,
+         channel_mapping: %{slow: ["alpha"], source: ["alpha"]},
+         call_timeout_ms: 10,
+         drop_threshold: 1,
+         notify_pid: self()}
+      )
+
+    {:ok, slow_worker} = TestWorker.start_link(self(), :sleep)
+    {:ok, source_worker} = TestWorker.start_link(self())
+
+    assert :ok = PipoSupervisor.Router.register_worker(router, :slow, slow_worker)
+    assert :ok = PipoSupervisor.Router.register_worker(router, :source, source_worker)
+
+    PipoSupervisor.Router.publish(router, :source, "alpha", %{})
+
+    assert_receive {:worker_degraded, :slow, 1, :timeout}, 500
   end
 end


### PR DESCRIPTION
### Motivation
- Provide an in-process router to fan out publish events between external transport workers based on configured channel subscriptions.
- Implement a port-backed worker that bridges an external `pipo-transport` binary to the router with clear lifecycle states and graceful shutdown.
- Ensure supervised startup ordering (router before workers), configurable restart intensity/window, and optional boot-time readiness gating so the system can detect degraded workers early.

### Description
- Add `PipoSupervisor.Router` as a `GenServer` that inverts `channel_mapping` into a `routing_table`, tracks `worker_pids`, `worker_health`, and `next_pipo_id`, fans out `publish` events (excluding the origin), delivers via `GenServer.call/3` with configurable timeout, and accounts for drops/degraded state and threshold notifications.
- Add `PipoSupervisor.PortWorker` as a `GenServer` that resolves the `pipo-transport` path (env override, release-relative, bundled fallback), launches the transport `Port` in binary+line mode, decodes/encodes NDJSON frames, forwards `publish` frames to the Router, enforces `ready_timeout_ms`, tracks `:starting/:ready/:degraded/:stopped`, and performs a graceful shutdown sequence.
- Add `PipoSupervisor.Supervisor` and update `PipoSupervisor.Application` to start the Router first and workers after using `:one_for_one`, with configurable `max_restarts`/`max_seconds` and optional `require_all_ready` boot behavior.
- Add a lightweight `PipoSupervisor.NDJSON` helper used by the worker to avoid a runtime dependency for transport framing, and add router-focused tests validating routing inversion/fanout and timeout-triggered degradation notifications.

### Testing
- Ran `mix format` in `apps/pipo_supervisor` successfully.
- Ran `mix test` in `apps/pipo_supervisor` and all tests passed (`2 tests, 0 failures`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b49b241328833182e770c4a794a1af)