### PR TITLE
Merge routing model types into transport_runtime lib

### DIFF
--- a/native/transport_runtime/src/lib.rs
+++ b/native/transport_runtime/src/lib.rs
@@ -1,5 +1,9 @@
 //! Transport runtime protocol primitives.
 
+use std::collections::HashMap;
+
+use serde_json::Value;
+
 pub mod protocol;
 
 /// Returns the supported protocol version string.
@@ -24,9 +28,65 @@ impl ExitCode {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SenderMeta {
+    pub channel: String,
+    pub pipo_id: Option<i64>,
+    pub origin_transport: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameKind {
+    Message,
+}
+
+pub type ChannelBusMap = HashMap<String, String>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoutedOutboundFrame {
+    pub kind: FrameKind,
+    pub bus: String,
+    pub pipo_id: Option<i64>,
+    pub origin_transport: String,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RuntimeRouter {
+    channel_bus_map: ChannelBusMap,
+}
+
+impl RuntimeRouter {
+    pub fn new(channel_bus_map: ChannelBusMap) -> Self {
+        Self { channel_bus_map }
+    }
+
+    pub fn bus_for_channel(&self, channel: &str) -> Option<&str> {
+        self.channel_bus_map.get(channel).map(String::as_str)
+    }
+
+    pub fn outbound_message(
+        &self,
+        sender: &SenderMeta,
+        payload: Value,
+    ) -> Option<RoutedOutboundFrame> {
+        let bus = self.bus_for_channel(&sender.channel)?.to_owned();
+        Some(RoutedOutboundFrame {
+            kind: FrameKind::Message,
+            bus,
+            pipo_id: sender.pipo_id,
+            origin_transport: sender.origin_transport.clone(),
+            payload,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{protocol_version, ExitCode};
+    use super::{
+        protocol_version, ChannelBusMap, ExitCode, FrameKind, RuntimeRouter, SenderMeta,
+    };
+    use serde_json::json;
 
     #[test]
     fn protocol_version_is_stable() {
@@ -42,5 +102,39 @@ mod tests {
         assert_eq!(ExitCode::TransportNetworkUnreachable.as_i32(), 11);
         assert_eq!(ExitCode::TransportFatal.as_i32(), 12);
         assert_eq!(ExitCode::InternalPanic.as_i32(), 20);
+    }
+
+    #[test]
+    fn channel_bus_mapping_resolves_for_known_channel() {
+        let mut map = ChannelBusMap::new();
+        map.insert("alerts".to_owned(), "ops".to_owned());
+        let router = RuntimeRouter::new(map);
+
+        assert_eq!(router.bus_for_channel("alerts"), Some("ops"));
+        assert_eq!(router.bus_for_channel("unknown"), None);
+    }
+
+    #[test]
+    fn outbound_message_routes_with_sender_metadata() {
+        let mut map = ChannelBusMap::new();
+        map.insert("alerts".to_owned(), "ops".to_owned());
+        let router = RuntimeRouter::new(map);
+
+        let sender = SenderMeta {
+            channel: "alerts".to_owned(),
+            pipo_id: Some(42),
+            origin_transport: "slack".to_owned(),
+        };
+
+        let payload = json!({"text": "hello"});
+        let frame = router
+            .outbound_message(&sender, payload.clone())
+            .expect("channel should be routable");
+
+        assert_eq!(frame.kind, FrameKind::Message);
+        assert_eq!(frame.bus, "ops");
+        assert_eq!(frame.pipo_id, Some(42));
+        assert_eq!(frame.origin_transport, "slack");
+        assert_eq!(frame.payload, payload);
     }
 }


### PR DESCRIPTION
### Motivation
- Add the routing model surface to the transport runtime so channels can be mapped to buses and sender metadata can be turned into routed outbound frames without changing the existing runtime protocol surface. 
- Avoid a naming collision with the protocol-level `OutboundFrame` while exposing router-local frame types for runtime logic.

### Description
- Kept `pub mod protocol;`, `protocol_version()` delegating to `protocol::SUPPORTED_PROTOCOL_VERSION`, and the existing `ExitCode` enum and its behavior. 
- Introduced routing model types: `SenderMeta`, `FrameKind`, `ChannelBusMap` (alias for `HashMap<String, String>`), `RoutedOutboundFrame`, and `RuntimeRouter` with `bus_for_channel` and `outbound_message`. 
- Resolved the naming overlap by using `RoutedOutboundFrame` for router output instead of reusing `protocol::OutboundFrame`. 
- Extended the test module in `native/transport_runtime/src/lib.rs` to keep protocol/version and exit-code assertions and add channel→bus mapping and sender-metadata routing assertions.

### Testing
- Ran `cargo test` in `native/transport_runtime` and the package tests completed successfully (unit tests passed and the package test run finished with all expected passing/ignored results). 
- Attempted `cargo test -p transport_runtime` from the repository root which failed due to the package ID/context mismatch for that invocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b0bd53288331a95ea083d9d39f0b)