### PR TITLE
Reduce Cargo.lock merge conflicts with union merge driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Reduce lockfile merge conflicts by preferring a union merge, then regenerate with `cargo generate-lockfile`.
+Cargo.lock merge=union


### PR DESCRIPTION
### Motivation
- Reduce manual merge conflicts for `Cargo.lock` by preferring Git's `union` merge driver so concurrent dependency updates merge more smoothly.

### Description
- Add a repository-level `.gitattributes` file containing `Cargo.lock merge=union` to instruct Git to prefer union merges for the lockfile.

### Testing
- Ran `git check-attr merge -- Cargo.lock` and `cargo generate-lockfile`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d224e4188331bfb8385c4f0a3bbb)