### PR TITLE
Add post‑MVP validation scaffolding, router dynamic subscription APIs, and target triple matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       - 'feature/matrix'
       - 'feature/elixir-supervisor'
 
+env:
+  SUPPORTED_TARGET_TRIPLES: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl
+
 jobs:
   rust-transport-runtime:
     name: Rust / native-transport-runtime (lint-test-build)
@@ -64,8 +67,15 @@ jobs:
         run: ./scripts/integration_protocol_supervision.sh
 
   tarball-assembly:
-    name: Packaging / tarball-assembly
+    name: Packaging / tarball-assembly (${{ matrix.target_triple }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_triple:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
     needs:
       - integration-protocol-supervision
     steps:
@@ -83,16 +93,25 @@ jobs:
           SCRIPT
           chmod +x bin/pipo_supervisor bin/pipo-transport
       - name: Assemble runtime tarball
+        env:
+          TARGET_TRIPLE: ${{ matrix.target_triple }}
         run: ./packaging/build_tarball.sh
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pipo-runtime
-          path: dist/pipo-*.tar.gz
+          name: pipo-runtime-${{ matrix.target_triple }}
+          path: dist/pipo-*-${{ matrix.target_triple }}.tar.gz
 
   extract-and-smoke-test:
-    name: Packaging / extract-and-smoke-test
+    name: Packaging / extract-and-smoke-test (${{ matrix.target_triple }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target_triple:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
     needs:
       - tarball-assembly
     steps:
@@ -100,15 +119,15 @@ jobs:
       - name: Download tarball artifact
         uses: actions/download-artifact@v4
         with:
-          name: pipo-runtime
+          name: pipo-runtime-${{ matrix.target_triple }}
           path: dist
       - name: Extract and smoke test
         run: |
           shopt -s nullglob
-          artifacts=(dist/pipo-*.tar.gz)
+          artifacts=(dist/pipo-*-${{ matrix.target_triple }}.tar.gz)
           shopt -u nullglob
           test "${#artifacts[@]}" -eq 1
-          ./packaging/smoke_test.sh "${artifacts[0]}" dist/smoke
+          ./packaging/smoke_test.sh "${artifacts[0]}" "dist/smoke-${{ matrix.target_triple }}"
 
   required-checks:
     name: Required / all-five-bootstrap-jobs

--- a/README-runtime.md
+++ b/README-runtime.md
@@ -3,3 +3,14 @@
 This runtime bundle is relocatable. Keep the directory layout intact and run
 `bin/pipo_supervisor` from the extracted root, using `etc/pipo/*.json` as
 templates for your runtime configuration.
+
+## Supported target triples
+
+Initial supported release artifacts are produced for:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `x86_64-unknown-linux-musl`
+
+Each release includes one tarball per target triple and a per-artifact
+`releases/manifest.json` describing the exact target and checksums.

--- a/apps/pipo_supervisor/lib/pipo_supervisor/router.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/router.ex
@@ -10,6 +10,7 @@ defmodule PipoSupervisor.Router do
   @default_drop_threshold 10
 
   defstruct routing_table: %{},
+            worker_buses: %{},
             worker_pids: %{},
             worker_health: %{},
             next_pipo_id: 1,
@@ -26,6 +27,18 @@ defmodule PipoSupervisor.Router do
     GenServer.call(router, {:register_worker, worker_id, pid})
   end
 
+  def unregister_worker(router \\ __MODULE__, worker_id) do
+    GenServer.call(router, {:unregister_worker, worker_id})
+  end
+
+  def add_subscription(router \\ __MODULE__, worker_id, bus) do
+    GenServer.call(router, {:add_subscription, worker_id, bus})
+  end
+
+  def remove_subscription(router \\ __MODULE__, worker_id, bus) do
+    GenServer.call(router, {:remove_subscription, worker_id, bus})
+  end
+
   def publish(router \\ __MODULE__, origin_worker_id, bus, payload) do
     GenServer.cast(router, {:publish, origin_worker_id, bus, payload})
   end
@@ -35,8 +48,12 @@ defmodule PipoSupervisor.Router do
     config = Application.get_env(:pipo_supervisor, :router, [])
     merged = Keyword.merge(config, opts)
 
+    {routing_table, worker_buses} =
+      build_routing_tables(Keyword.get(merged, :channel_mapping, %{}))
+
     state = %__MODULE__{
-      routing_table: build_routing_table(Keyword.get(merged, :channel_mapping, %{})),
+      routing_table: routing_table,
+      worker_buses: worker_buses,
       call_timeout_ms: Keyword.get(merged, :call_timeout_ms, @default_call_timeout_ms),
       drop_threshold: Keyword.get(merged, :drop_threshold, @default_drop_threshold),
       notify_pid: Keyword.get(merged, :notify_pid)
@@ -53,6 +70,18 @@ defmodule PipoSupervisor.Router do
     worker_health = Map.put_new(state.worker_health, worker_id, %{degraded?: false, drops: 0})
 
     {:reply, :ok, %{state | worker_pids: worker_pids, worker_health: worker_health}}
+  end
+
+  def handle_call({:unregister_worker, worker_id}, _from, state) do
+    {:reply, :ok, unregister_worker_from_state(state, worker_id)}
+  end
+
+  def handle_call({:add_subscription, worker_id, bus}, _from, state) do
+    {:reply, :ok, add_subscription_to_state(state, worker_id, bus)}
+  end
+
+  def handle_call({:remove_subscription, worker_id, bus}, _from, state) do
+    {:reply, :ok, remove_subscription_from_state(state, worker_id, bus)}
   end
 
   def handle_call({:deliver, _frame}, _from, state) do
@@ -81,12 +110,17 @@ defmodule PipoSupervisor.Router do
 
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    worker_pids =
+    down_worker_id =
       state.worker_pids
-      |> Enum.reject(fn {_worker_id, {_pid, mref}} -> mref == ref end)
-      |> Map.new()
+      |> Enum.find_value(fn {worker_id, {_pid, mref}} -> if mref == ref, do: worker_id end)
 
-    {:noreply, %{state | worker_pids: worker_pids}}
+    next_state =
+      case down_worker_id do
+        nil -> state
+        worker_id -> unregister_worker_from_state(state, worker_id)
+      end
+
+    {:noreply, next_state}
   end
 
   defp deliver_to_worker(state, worker_id, frame) do
@@ -141,11 +175,80 @@ defmodule PipoSupervisor.Router do
 
   defp maybe_notify_degraded(_pid, _worker_id, _drops, _threshold, _reason), do: :ok
 
-  defp build_routing_table(channel_mapping) when is_map(channel_mapping) do
-    Enum.reduce(channel_mapping, %{}, fn {worker_id, busses}, acc ->
-      Enum.reduce(List.wrap(busses), acc, fn bus, inner ->
-        Map.update(inner, bus, MapSet.new([worker_id]), &MapSet.put(&1, worker_id))
+  defp build_routing_tables(channel_mapping) when is_map(channel_mapping) do
+    Enum.reduce(channel_mapping, {%{}, %{}}, fn {worker_id, busses},
+                                                {routing_table, worker_buses} ->
+      Enum.reduce(List.wrap(busses), {routing_table, worker_buses}, fn bus,
+                                                                       {inner_routing,
+                                                                        inner_worker_buses} ->
+        next_routing =
+          Map.update(inner_routing, bus, MapSet.new([worker_id]), &MapSet.put(&1, worker_id))
+
+        next_worker_buses =
+          Map.update(inner_worker_buses, worker_id, MapSet.new([bus]), &MapSet.put(&1, bus))
+
+        {next_routing, next_worker_buses}
       end)
     end)
+  end
+
+  defp unregister_worker_from_state(state, worker_id) do
+    worker_pids = Map.delete(state.worker_pids, worker_id)
+    worker_health = Map.delete(state.worker_health, worker_id)
+
+    {routing_table, worker_buses} =
+      case Map.get(state.worker_buses, worker_id) do
+        nil ->
+          {state.routing_table, state.worker_buses}
+
+        busses ->
+          remove_worker_from_buses(state.routing_table, state.worker_buses, worker_id, busses)
+      end
+
+    %{
+      state
+      | worker_pids: worker_pids,
+        worker_health: worker_health,
+        routing_table: routing_table,
+        worker_buses: worker_buses
+    }
+  end
+
+  defp add_subscription_to_state(state, worker_id, bus) do
+    routing_table =
+      Map.update(state.routing_table, bus, MapSet.new([worker_id]), &MapSet.put(&1, worker_id))
+
+    worker_buses =
+      Map.update(state.worker_buses, worker_id, MapSet.new([bus]), &MapSet.put(&1, bus))
+
+    %{state | routing_table: routing_table, worker_buses: worker_buses}
+  end
+
+  defp remove_subscription_from_state(state, worker_id, bus) do
+    routing_table =
+      case Map.get(state.routing_table, bus, MapSet.new()) |> MapSet.delete(worker_id) do
+        set when map_size(set) == 0 -> Map.delete(state.routing_table, bus)
+        set -> Map.put(state.routing_table, bus, set)
+      end
+
+    worker_buses =
+      case Map.get(state.worker_buses, worker_id, MapSet.new()) |> MapSet.delete(bus) do
+        set when map_size(set) == 0 -> Map.delete(state.worker_buses, worker_id)
+        set -> Map.put(state.worker_buses, worker_id, set)
+      end
+
+    %{state | routing_table: routing_table, worker_buses: worker_buses}
+  end
+
+  defp remove_worker_from_buses(routing_table, worker_buses, worker_id, busses) do
+    next_routing =
+      Enum.reduce(busses, routing_table, fn bus, acc ->
+        case Map.get(acc, bus, MapSet.new()) |> MapSet.delete(worker_id) do
+          set when map_size(set) == 0 -> Map.delete(acc, bus)
+          set -> Map.put(acc, bus, set)
+        end
+      end)
+
+    {next_routing, Map.delete(worker_buses, worker_id)}
   end
 end

--- a/apps/pipo_supervisor/test/pipo_supervisor_test.exs
+++ b/apps/pipo_supervisor/test/pipo_supervisor_test.exs
@@ -68,4 +68,38 @@ defmodule PipoSupervisor.RouterTest do
 
     assert_receive {:worker_degraded, :slow, 1, :timeout}, 500
   end
+
+  test "supports dynamic add/remove subscriptions and worker unregister" do
+    {:ok, router} =
+      start_supervised(
+        {PipoSupervisor.Router, name: :router_test_3, channel_mapping: %{source: ["alpha"]}}
+      )
+
+    {:ok, source_worker} = TestWorker.start_link(self())
+    {:ok, dynamic_worker} = TestWorker.start_link(self())
+
+    assert :ok = PipoSupervisor.Router.register_worker(router, :source, source_worker)
+    assert :ok = PipoSupervisor.Router.register_worker(router, :dynamic, dynamic_worker)
+
+    assert :ok = PipoSupervisor.Router.add_subscription(router, :dynamic, "alpha")
+
+    PipoSupervisor.Router.publish(router, :source, "alpha", %{"phase" => "added"})
+
+    assert_receive {:delivered, ^dynamic_worker,
+                    %{"bus" => "alpha", "payload" => %{"phase" => "added"}}},
+                   500
+
+    assert :ok = PipoSupervisor.Router.remove_subscription(router, :dynamic, "alpha")
+
+    PipoSupervisor.Router.publish(router, :source, "alpha", %{"phase" => "removed"})
+    refute_receive {:delivered, ^dynamic_worker, %{"payload" => %{"phase" => "removed"}}}, 150
+
+    assert :ok = PipoSupervisor.Router.unregister_worker(router, :dynamic)
+    assert :ok = PipoSupervisor.Router.add_subscription(router, :dynamic, "alpha")
+
+    PipoSupervisor.Router.publish(router, :source, "alpha", %{"phase" => "unregistered"})
+
+    refute_receive {:delivered, ^dynamic_worker, %{"payload" => %{"phase" => "unregistered"}}},
+                   150
+  end
 end

--- a/native/transport_runtime/tests/runtime_spec.rs
+++ b/native/transport_runtime/tests/runtime_spec.rs
@@ -92,6 +92,28 @@ fn auth_failure_exits_code_10() {
     assert_eq!(status.code(), Some(10));
 }
 
+
+#[test]
+#[ignore = "pending chaos validation harness"]
+fn chaos_restart_storm_recovers_without_supervisor_deadlock() {
+    let status = run_runtime_check("chaos-restart-storm", "");
+    assert!(status.success(), "restart storm scenario should recover predictably");
+}
+
+#[test]
+#[ignore = "pending long-run stability harness"]
+fn long_run_stability_memory_trend_remains_bounded() {
+    let status = run_runtime_check("long-run-memory-trend", "");
+    assert!(status.success(), "long-run memory profile should remain bounded");
+}
+
+#[test]
+#[ignore = "pending compatibility matrix harness"]
+fn compatibility_matrix_covers_supported_target_triples() {
+    let status = run_packaging_check(["compatibility-matrix"]);
+    assert!(status.success(), "supported target triples should pass compatibility checks");
+}
+
 #[test]
 #[ignore = "pending release packaging pipeline"]
 fn packaging_tarball_contains_required_paths() {

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,3 +2,14 @@
 
 - `build_tarball.sh` assembles the runtime tarball as `pipo-<version>-<target>.tar.gz`.
 - `smoke_test.sh` extracts a tarball and validates runtime startup behavior.
+
+## Initial supported target triples
+
+The initial post-MVP supported release targets are:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `x86_64-unknown-linux-musl`
+
+CI builds and smoke-tests a tarball for each supported target to keep packaging
+and release artifacts aligned with the declared compatibility matrix.

--- a/specs/v1.md
+++ b/specs/v1.md
@@ -330,7 +330,7 @@ Release publish is gated on all above passing.
 
 ### Phase 4 — Hardening
 1. Add chaos-style tests for repeated crash/restart.
-2. Validate long-running stability and memory growth.
+2. Validate long-running stability and memory growth trends.
 3. Verify compatibility matrix for supported target triples.
 4. Harden dynamic transport add/remove operations in the Router.
 
@@ -367,6 +367,19 @@ The following decisions have been resolved:
 2. **Timestamp format**: RFC3339 strings, UTC only, millisecond precision (`"2026-03-13T12:00:00.000Z"`). Enforced by schema fixtures.
 3. **Boot behavior on failed readiness**: start degraded by default (`require_all_ready: false`); `require_all_ready: true` available as a config flag and required for CI smoke tests.
 
-The following decision remains open and must be resolved before Phase 3:
+All open decisions are now resolved:
 
-4. **Deployment target triples**: initial set of supported targets for tarball releases has not been specified.
+4. **Deployment target triples**: initial supported tarball release targets are `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, and `x86_64-unknown-linux-musl`. CI packaging and smoke-test jobs run for each target in this matrix.
+
+## 15. Post-MVP Validation Plan
+
+Post-MVP validation extends Phase 4 with the following checks:
+
+1. **Chaos/restart storm tests**
+   - Repeated worker crash/restart simulations must confirm supervisor recovery without deadlock and with bounded restart intensity behavior.
+2. **Long-run stability and memory trend checks**
+   - Multi-hour burn-in runs track process memory footprint and assert non-divergent trends under representative routing traffic.
+3. **Compatibility matrix tests**
+   - Packaging and smoke-test validation must run across each supported target triple (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`).
+4. **Router dynamic add/remove hardening groundwork**
+   - Router state keeps mutable forward and reverse routing indexes so workers and subscriptions can be safely added/removed without stale fanout entries.


### PR DESCRIPTION
### Motivation

- Implement post‑MVP validation coverage for chaos/restart storms, long‑run stability/memory trends, and compatibility matrix checks so hardening can be codified and automated.
- Harden router runtime behavior to support safe dynamic add/remove of transports/subscriptions without leaving stale fanout state.
- Resolve the open deployment decision by declaring an initial compatibility matrix of target triples and reflect that in packaging/CI and release docs.

### Description

- Extend `PipoSupervisor.Router` with a reverse index (`worker_buses`), new APIs `unregister_worker/2`, `add_subscription/3`, `remove_subscription/3`, and `:DOWN` cleanup to remove stale routing entries and subscriptions.
- Add an Elixir router test exercising dynamic add/remove subscriptions and worker unregister while preserving existing routing and degraded behavior tests (`apps/pipo_supervisor/test/pipo_supervisor_test.exs`).
- Add ignored scaffolding tests for chaos/restart storms, long‑run memory trend checks, and compatibility matrix validation to the runtime test suite (`native/transport_runtime/tests/runtime_spec.rs`) to codify expected post‑MVP checks.
- Convert packaging jobs into a per‑target matrix in CI (`.github/workflows/build.yml`) and update packaging/release docs (`packaging/README.md`, `README-runtime.md`, and `specs/v1.md`) to declare the initial supported target triples: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, and `x86_64-unknown-linux-musl`.

### Testing

- Ran `mix format` in `apps/pipo_supervisor` and it completed successfully.
- Ran `mix test` in `apps/pipo_supervisor` and the test suite passed (3 tests, 0 failures).
- Ran `cargo test -p transport_runtime --test runtime_spec` which executed the suite with the new ignored scaffolding; all tests were present and marked ignored (0 failed, 18 ignored) and the run completed successfully.
- Running `cargo test -p transport_runtime --test runtime_spec -- --ignored` fails as expected today because the ignored post‑MVP harnesses/binaries (e.g. `scripts/runtime_harness.sh`, `scripts/packaging_harness.sh`, or a `pipo-transport` runtime) are not yet implemented, so those end‑to‑end checks remain gated behind harness implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f160691c8331a5b862c860edc00d)