### PR TITLE
Add CI publish gate and dynamic packaging matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,29 @@ env:
   SUPPORTED_TARGET_TRIPLES: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl
 
 jobs:
+  resolve-targets:
+    name: Resolve packaging target matrix
+    runs-on: ubuntu-latest
+    outputs:
+      target_matrix: ${{ steps.resolve.outputs.target_matrix }}
+    steps:
+      - name: Resolve targets from SUPPORTED_TARGET_TRIPLES
+        id: resolve
+        env:
+          SUPPORTED_TARGET_TRIPLES: ${{ env.SUPPORTED_TARGET_TRIPLES }}
+        run: |
+          python - <<'PYTHON' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          raw = os.environ["SUPPORTED_TARGET_TRIPLES"]
+          targets = [item.strip() for item in raw.split(",") if item.strip()]
+          if not targets:
+            raise SystemExit("SUPPORTED_TARGET_TRIPLES must include at least one target")
+
+          print(f"target_matrix={json.dumps({'target_triple': targets})}")
+          PYTHON
+
   rust-transport-runtime:
     name: Rust / native-transport-runtime (lint-test-build)
     runs-on: ubuntu-latest
@@ -71,12 +94,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        target_triple:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
+      matrix: ${{ fromJson(needs.resolve-targets.outputs.target_matrix) }}
     needs:
+      - resolve-targets
       - integration-protocol-supervision
     steps:
       - uses: actions/checkout@v4
@@ -114,12 +134,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        target_triple:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
+      matrix: ${{ fromJson(needs.resolve-targets.outputs.target_matrix) }}
     needs:
+      - resolve-targets
       - tarball-assembly
     steps:
       - uses: actions/checkout@v4
@@ -136,24 +153,27 @@ jobs:
           test "${#artifacts[@]}" -eq 1
           ./packaging/smoke_test.sh "${artifacts[0]}" "dist/smoke-${{ matrix.target_triple }}"
 
-  required-checks:
-    name: Required / all-five-bootstrap-jobs
+  publish-gate:
+    name: Publish gate / all ci jobs passed
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - resolve-targets
       - rust-transport-runtime
       - elixir-pipo-supervisor
       - integration-protocol-supervision
       - tarball-assembly
       - extract-and-smoke-test
     steps:
-      - name: Enforce required CI jobs
+      - name: Enforce publish gate
         run: |
+          echo "Resolve targets: ${{ needs.resolve-targets.result }}"
           echo "Rust job: ${{ needs.rust-transport-runtime.result }}"
           echo "Elixir job: ${{ needs.elixir-pipo-supervisor.result }}"
           echo "Integration job: ${{ needs.integration-protocol-supervision.result }}"
           echo "Tarball job: ${{ needs.tarball-assembly.result }}"
           echo "Smoke job: ${{ needs.extract-and-smoke-test.result }}"
+          test "${{ needs.resolve-targets.result }}" = "success"
           test "${{ needs.rust-transport-runtime.result }}" = "success"
           test "${{ needs.elixir-pipo-supervisor.result }}" = "success"
           test "${{ needs.integration-protocol-supervision.result }}" = "success"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,3 +13,8 @@ The initial post-MVP supported release targets are:
 
 CI builds and smoke-tests a tarball for each supported target to keep packaging
 and release artifacts aligned with the declared compatibility matrix.
+
+The CI workflow resolves the target matrix from `SUPPORTED_TARGET_TRIPLES` and
+runs both tarball assembly and extraction smoke tests per resolved target.
+Release publishing is guarded by the `publish-gate` job, which requires all
+upstream CI jobs to succeed.


### PR DESCRIPTION
### Motivation
- Ensure packaging runs for the declared target triples without duplicated lists and centralize matrix resolution so targets are maintained in one place.
- Prevent publishing unless all CI jobs (including per-target packaging assembly and smoke tests) have completed successfully.

### Description
- Added a `resolve-targets` job to `.github/workflows/build.yml` that converts `SUPPORTED_TARGET_TRIPLES` into a JSON matrix output consumed by downstream jobs via `needs.resolve-targets.outputs.target_matrix` using inline Python.
- Updated `tarball-assembly` and `extract-and-smoke-test` to use `matrix: ${{ fromJson(needs.resolve-targets.outputs.target_matrix) }}` and depend on `resolve-targets` so packaging runs for each resolved target triple.
- Replaced the previous aggregate check job with a `publish-gate` job that `needs` all upstream jobs (including packaging jobs) and exits non-zero unless every upstream job result is `success`.
- Documented the resolved-matrix behavior and publish gating in `packaging/README.md`.

### Testing
- Parsed the updated workflow with a Ruby YAML loader using `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/build.yml'); raise 'missing publish-gate' unless data['jobs']['publish-gate']"`, which succeeded and verified the `publish-gate` job is present.
- Attempted to parse the workflow with Python `yaml.safe_load`, which failed due to `PyYAML` not being installed in the environment (known environment limitation).
- Used repository inspections (`rg`/`git diff`) to confirm the `resolve-targets` job, matrix usage in packaging jobs, and the presence of `publish-gate` and README updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b604c5974c8331abe1a71f54d572c5)