### PR TITLE
Add burn-in profile for long-run stability and memory guardrails

### DIFF
--- a/apps/pipo_supervisor/lib/mix/tasks/pipo.burn_in.ex
+++ b/apps/pipo_supervisor/lib/mix/tasks/pipo.burn_in.ex
@@ -1,0 +1,92 @@
+defmodule Mix.Tasks.Pipo.BurnIn do
+  use Mix.Task
+
+  @shortdoc "Runs long-running router/worker burn-in stability validation"
+
+  @moduledoc """
+  Runs the Pipo supervisor burn-in profile with representative router traffic.
+
+  Example (multi-hour profile):
+
+      mix pipo.burn_in --duration-hours 4 --sample-interval-ms 5000 --publish-interval-ms 25
+  """
+
+  @switches [
+    duration_hours: :integer,
+    duration_ms: :integer,
+    sample_interval_ms: :integer,
+    publish_interval_ms: :integer,
+    call_timeout_ms: :integer,
+    growth_limit_mb: :integer,
+    max_stall_ms: :integer,
+    min_delivery_ratio: :float
+  ]
+
+  @impl true
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: @switches)
+
+    duration_ms =
+      cond do
+        opts[:duration_ms] -> opts[:duration_ms]
+        opts[:duration_hours] -> :timer.hours(opts[:duration_hours])
+        true -> :timer.hours(4)
+      end
+
+    run_opts =
+      [duration_ms: duration_ms]
+      |> put_opt(opts, :sample_interval_ms)
+      |> put_opt(opts, :publish_interval_ms)
+      |> put_opt(opts, :call_timeout_ms)
+      |> put_opt_mb(opts, :growth_limit_mb, :growth_limit_bytes)
+      |> put_opt(opts, :max_stall_ms)
+      |> put_opt(opts, :min_delivery_ratio)
+
+    case PipoSupervisor.BurnIn.run(run_opts) do
+      {:ok, report} ->
+        Mix.shell().info("burn-in passed")
+        Mix.shell().info(format_report(report))
+
+      {:error, report} ->
+        Mix.shell().error("burn-in failed")
+        Mix.shell().error(format_report(report))
+        Mix.raise("burn-in guardrails failed")
+    end
+  end
+
+  defp put_opt(run_opts, parsed, key) do
+    case parsed[key] do
+      nil -> run_opts
+      value -> Keyword.put(run_opts, key, value)
+    end
+  end
+
+  defp put_opt_mb(run_opts, parsed, mb_key, bytes_key) do
+    case parsed[mb_key] do
+      nil -> run_opts
+      mb -> Keyword.put(run_opts, bytes_key, mb * 1024 * 1024)
+    end
+  end
+
+  defp format_report(report) do
+    memory_lines =
+      report.memory
+      |> Enum.map(fn {name, details} ->
+        "  #{name}: pass=#{details.pass?} growth_bytes=#{details.growth_bytes} monotonic=#{details.monotonic_non_decreasing?}"
+      end)
+      |> Enum.join("\n")
+
+    """
+    pass?: #{report.pass?}
+    duration_ms: #{report.duration_ms}
+    counters: published=#{report.counters.published} delivered=#{report.counters.delivered}
+    deadlock_livelock: #{inspect(report.guardrails.deadlock_livelock)}
+    message_flow: #{inspect(report.guardrails.message_flow)}
+    transient_failure_recovery: #{inspect(report.guardrails.transient_failure_recovery)}
+    memory:
+    #{memory_lines}
+    """
+  end
+end

--- a/apps/pipo_supervisor/lib/pipo_supervisor/burn_in.ex
+++ b/apps/pipo_supervisor/lib/pipo_supervisor/burn_in.ex
@@ -1,0 +1,304 @@
+defmodule PipoSupervisor.BurnIn do
+  @moduledoc """
+  Burn-in profile runner for long-running stability and memory trend validation.
+
+  It drives representative publish traffic through `PipoSupervisor.Router`, samples
+  per-process memory usage for the router and workers, and evaluates guardrails:
+
+    * no monotonic, unbounded memory growth
+    * no deadlock/livelock
+    * stable message flow despite transient worker failures
+  """
+
+  @default_duration_ms :timer.hours(4)
+  @default_publish_interval_ms 25
+  @default_sample_interval_ms 5_000
+  @default_call_timeout_ms 20
+  @default_growth_limit_bytes 32 * 1024 * 1024
+  @default_max_stall_ms 10_000
+  @default_min_delivery_ratio 0.60
+
+  def run(opts \\ []) do
+    duration_ms = Keyword.get(opts, :duration_ms, @default_duration_ms)
+    publish_interval_ms = Keyword.get(opts, :publish_interval_ms, @default_publish_interval_ms)
+    sample_interval_ms = Keyword.get(opts, :sample_interval_ms, @default_sample_interval_ms)
+    call_timeout_ms = Keyword.get(opts, :call_timeout_ms, @default_call_timeout_ms)
+    growth_limit_bytes = Keyword.get(opts, :growth_limit_bytes, @default_growth_limit_bytes)
+    max_stall_ms = Keyword.get(opts, :max_stall_ms, @default_max_stall_ms)
+    min_delivery_ratio = Keyword.get(opts, :min_delivery_ratio, @default_min_delivery_ratio)
+
+    run_id = System.unique_integer([:positive])
+    router_name = String.to_atom("burn_in_router_#{run_id}")
+
+    {:ok, counter} =
+      Agent.start_link(fn -> %{published: 0, delivered: 0, last_delivery_at: nil} end)
+
+    {:ok, router} =
+      PipoSupervisor.Router.start_link(
+        name: router_name,
+        call_timeout_ms: call_timeout_ms,
+        drop_threshold: 1,
+        notify_pid: self(),
+        channel_mapping: %{stable_a: ["alpha"], stable_b: ["alpha"], flaky: ["alpha"]}
+      )
+
+    {:ok, stable_a} = __MODULE__.BurnInWorker.start_link(id: :stable_a, counter: counter)
+    {:ok, stable_b} = __MODULE__.BurnInWorker.start_link(id: :stable_b, counter: counter)
+
+    {:ok, flaky} =
+      __MODULE__.BurnInWorker.start_link(id: :flaky, counter: counter, fail_mode: :toggle)
+
+    :ok = PipoSupervisor.Router.register_worker(router, :stable_a, stable_a)
+    :ok = PipoSupervisor.Router.register_worker(router, :stable_b, stable_b)
+    :ok = PipoSupervisor.Router.register_worker(router, :flaky, flaky)
+
+    publisher = spawn_link(fn -> publish_loop(router, counter, publish_interval_ms, 1) end)
+    flapper = spawn_link(fn -> failure_loop(flaky, 600, 250) end)
+
+    tracked = %{router: router, stable_a: stable_a, stable_b: stable_b, flaky: flaky}
+
+    started_at = System.monotonic_time(:millisecond)
+
+    {samples, transitions} =
+      collect_samples(tracked, started_at, duration_ms, sample_interval_ms, [])
+
+    send(publisher, :stop)
+    send(flapper, :stop)
+
+    counters = Agent.get(counter, & &1)
+
+    report =
+      build_report(
+        samples,
+        transitions,
+        counters,
+        started_at,
+        growth_limit_bytes,
+        max_stall_ms,
+        min_delivery_ratio
+      )
+
+    Process.exit(router, :normal)
+    Process.exit(stable_a, :normal)
+    Process.exit(stable_b, :normal)
+    Process.exit(flaky, :normal)
+    Agent.stop(counter)
+
+    if report.pass?, do: {:ok, report}, else: {:error, report}
+  end
+
+  defp collect_samples(tracked, started_at, duration_ms, sample_interval_ms, transitions) do
+    now = System.monotonic_time(:millisecond)
+    elapsed = now - started_at
+
+    sample =
+      tracked
+      |> Enum.map(fn {name, pid} ->
+        mem = if Process.alive?(pid), do: process_memory(pid), else: 0
+        {name, %{pid: pid, memory_bytes: mem}}
+      end)
+      |> Map.new()
+      |> Map.put(:at_ms, elapsed)
+
+    transitions = drain_transitions(transitions)
+
+    if elapsed >= duration_ms do
+      {[sample], transitions}
+    else
+      Process.sleep(sample_interval_ms)
+
+      {tail, transitions} =
+        collect_samples(tracked, started_at, duration_ms, sample_interval_ms, transitions)
+
+      {[sample | tail], transitions}
+    end
+  end
+
+  defp drain_transitions(transitions) do
+    receive do
+      {:worker_degraded, worker_id, drops, reason} ->
+        stamp = System.monotonic_time(:millisecond)
+        drain_transitions([{:degraded, worker_id, drops, reason, stamp} | transitions])
+
+      {:worker_restored, worker_id} ->
+        stamp = System.monotonic_time(:millisecond)
+        drain_transitions([{:restored, worker_id, stamp} | transitions])
+    after
+      0 -> Enum.reverse(transitions)
+    end
+  end
+
+  defp process_memory(pid) do
+    case Process.info(pid, :memory) do
+      {:memory, bytes} -> bytes
+      _ -> 0
+    end
+  end
+
+  defp publish_loop(router, counter, interval_ms, seq) do
+    receive do
+      :stop ->
+        :ok
+    after
+      interval_ms ->
+        payload = %{"seq" => seq, "at_ms" => System.monotonic_time(:millisecond)}
+        PipoSupervisor.Router.publish(router, :source, "alpha", payload)
+        Agent.update(counter, &Map.update!(&1, :published, fn x -> x + 1 end))
+        publish_loop(router, counter, interval_ms, seq + 1)
+    end
+  end
+
+  defp failure_loop(worker_pid, healthy_ms, failing_ms) do
+    receive do
+      :stop ->
+        :ok
+    after
+      healthy_ms ->
+        __MODULE__.BurnInWorker.set_failure(worker_pid, true)
+        Process.sleep(failing_ms)
+        __MODULE__.BurnInWorker.set_failure(worker_pid, false)
+        failure_loop(worker_pid, healthy_ms, failing_ms)
+    end
+  end
+
+  defp build_report(
+         samples,
+         transitions,
+         counters,
+         started_at,
+         growth_limit_bytes,
+         max_stall_ms,
+         min_delivery_ratio
+       ) do
+    ended_at = System.monotonic_time(:millisecond)
+    duration_ms = ended_at - started_at
+
+    memory =
+      [:router, :stable_a, :stable_b, :flaky]
+      |> Enum.map(fn name -> {name, memory_profile(samples, name, growth_limit_bytes)} end)
+      |> Map.new()
+
+    deadlock = deadlock_guardrail(counters, duration_ms, max_stall_ms)
+    flow = flow_guardrail(counters, min_delivery_ratio)
+    recovery = recovery_guardrail(transitions)
+
+    pass? =
+      Enum.all?([deadlock.pass?, flow.pass?, recovery.pass?]) and
+        Enum.all?(Map.values(memory), & &1.pass?)
+
+    %{
+      pass?: pass?,
+      duration_ms: duration_ms,
+      counters: counters,
+      transitions: transitions,
+      memory: memory,
+      guardrails: %{
+        memory: memory,
+        deadlock_livelock: deadlock,
+        message_flow: flow,
+        transient_failure_recovery: recovery
+      }
+    }
+  end
+
+  defp memory_profile(samples, name, growth_limit_bytes) do
+    series = Enum.map(samples, &get_in(&1, [name, :memory_bytes]))
+    start_mem = List.first(series) || 0
+    end_mem = List.last(series) || 0
+    growth = end_mem - start_mem
+    monotonic? = monotonic_non_decreasing?(series)
+    bounded? = growth <= growth_limit_bytes
+    pass? = not monotonic? or bounded?
+
+    %{
+      pass?: pass?,
+      start_bytes: start_mem,
+      end_bytes: end_mem,
+      growth_bytes: growth,
+      monotonic_non_decreasing?: monotonic?,
+      bounded_growth?: bounded?
+    }
+  end
+
+  defp monotonic_non_decreasing?([_single]), do: true
+  defp monotonic_non_decreasing?([]), do: true
+
+  defp monotonic_non_decreasing?(series) do
+    series
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.all?(fn [a, b] -> b >= a end)
+  end
+
+  defp deadlock_guardrail(counters, duration_ms, max_stall_ms) do
+    stalled_ms =
+      case counters.last_delivery_at do
+        nil -> duration_ms
+        ts -> System.monotonic_time(:millisecond) - ts
+      end
+
+    pass? = counters.published > 0 and counters.delivered > 0 and stalled_ms <= max_stall_ms
+
+    %{pass?: pass?, stalled_ms: stalled_ms, max_stall_ms: max_stall_ms}
+  end
+
+  defp flow_guardrail(counters, min_delivery_ratio) do
+    ratio =
+      if counters.published == 0,
+        do: 0.0,
+        else: counters.delivered / max(counters.published * 3, 1)
+
+    pass? = ratio >= min_delivery_ratio
+
+    %{pass?: pass?, delivery_ratio: ratio, min_delivery_ratio: min_delivery_ratio}
+  end
+
+  defp recovery_guardrail(transitions) do
+    degraded = Enum.count(transitions, &(elem(&1, 0) == :degraded))
+    restored = Enum.count(transitions, &(elem(&1, 0) == :restored))
+    pass? = degraded > 0 and restored > 0
+    %{pass?: pass?, degraded_events: degraded, restored_events: restored}
+  end
+
+  defmodule BurnInWorker do
+    use GenServer
+
+    def start_link(opts) do
+      GenServer.start_link(__MODULE__, opts)
+    end
+
+    def set_failure(pid, enabled) do
+      GenServer.cast(pid, {:set_failure, enabled})
+    end
+
+    @impl true
+    def init(opts) do
+      {:ok,
+       %{
+         id: Keyword.fetch!(opts, :id),
+         counter: Keyword.fetch!(opts, :counter),
+         fail_mode: Keyword.get(opts, :fail_mode, :never),
+         failing?: false
+       }}
+    end
+
+    @impl true
+    def handle_cast({:set_failure, enabled}, state), do: {:noreply, %{state | failing?: enabled}}
+
+    @impl true
+    def handle_call({:deliver, _frame}, _from, %{fail_mode: :toggle, failing?: true} = state) do
+      {:reply, {:error, :transient_failure}, state}
+    end
+
+    def handle_call({:deliver, _frame}, _from, state) do
+      now = System.monotonic_time(:millisecond)
+
+      Agent.update(state.counter, fn counters ->
+        counters
+        |> Map.update!(:delivered, &(&1 + 1))
+        |> Map.put(:last_delivery_at, now)
+      end)
+
+      {:reply, :ok, state}
+    end
+  end
+end

--- a/apps/pipo_supervisor/test/burn_in_test.exs
+++ b/apps/pipo_supervisor/test/burn_in_test.exs
@@ -1,0 +1,44 @@
+defmodule PipoSupervisor.BurnInTest do
+  use ExUnit.Case, async: false
+
+  test "short burn-in run produces passing guardrails and process memory series" do
+    assert {:ok, report} =
+             PipoSupervisor.BurnIn.run(
+               duration_ms: 1_200,
+               publish_interval_ms: 10,
+               sample_interval_ms: 100,
+               call_timeout_ms: 15,
+               growth_limit_bytes: 16 * 1024 * 1024,
+               max_stall_ms: 500,
+               min_delivery_ratio: 0.4
+             )
+
+    assert report.pass?
+    assert report.guardrails.deadlock_livelock.pass?
+    assert report.guardrails.message_flow.pass?
+    assert report.guardrails.transient_failure_recovery.pass?
+
+    assert Map.has_key?(report.memory, :router)
+    assert Map.has_key?(report.memory, :stable_a)
+    assert Map.has_key?(report.memory, :stable_b)
+    assert Map.has_key?(report.memory, :flaky)
+
+    assert Enum.all?(Map.values(report.memory), &is_boolean(&1.pass?))
+    assert report.counters.published > 0
+    assert report.counters.delivered > 0
+  end
+
+  test "fails when strict delivery ratio guardrail is not achievable" do
+    assert {:error, report} =
+             PipoSupervisor.BurnIn.run(
+               duration_ms: 700,
+               publish_interval_ms: 10,
+               sample_interval_ms: 100,
+               call_timeout_ms: 10,
+               min_delivery_ratio: 0.98
+             )
+
+    refute report.pass?
+    refute report.guardrails.message_flow.pass?
+  end
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Docs
 
-Placeholder documentation root for architecture and release process notes.
+- `burn_in.md`: long-running stability and memory trend validation profile and guardrails.

--- a/docs/burn_in.md
+++ b/docs/burn_in.md
@@ -1,0 +1,61 @@
+# Long-running stability and memory trend validation
+
+Use the burn-in profile to validate router/worker stability under representative
+routing traffic over multi-hour runs.
+
+## Burn-in profile
+
+The profile is implemented by `PipoSupervisor.BurnIn` and exposed via:
+
+```bash
+cd apps/pipo_supervisor
+mix pipo.burn_in --duration-hours 4 --publish-interval-ms 25 --sample-interval-ms 5000
+```
+
+### Traffic model
+
+- Continuous `publish` flow on bus `alpha` from a source identity.
+- Three subscribers (`stable_a`, `stable_b`, `flaky`).
+- The `flaky` worker is periodically forced into transient timeout behavior,
+  then restored.
+
+This creates realistic fanout traffic with intermittent worker degradation and
+recovery while maintaining message throughput.
+
+## Collected signals
+
+- Per-process memory samples for:
+  - `Router`
+  - `stable_a`
+  - `stable_b`
+  - `flaky`
+- Delivery and publish counters.
+- Degraded/restored transition notifications emitted by the router.
+
+## Pass/fail guardrails
+
+The run fails if any guardrail fails:
+
+1. **No monotonic, unbounded memory growth**
+   - For each tracked process, detect monotonic non-decreasing memory series.
+   - If monotonic and growth exceeds configured limit (`growth_limit_bytes`),
+     fail.
+
+2. **No deadlock/livelock**
+   - Require published and delivered counters to continue increasing.
+   - Fail if the `last_delivery_at` stall exceeds `max_stall_ms`.
+
+3. **Stable message flow despite transient worker failures**
+   - Require a minimum delivery ratio (`min_delivery_ratio`) even with flaky
+     worker timeouts.
+   - Require both degradation and restoration transitions to be observed.
+
+## Useful options
+
+- `--duration-hours` / `--duration-ms`
+- `--publish-interval-ms`
+- `--sample-interval-ms`
+- `--call-timeout-ms`
+- `--growth-limit-mb`
+- `--max-stall-ms`
+- `--min-delivery-ratio`


### PR DESCRIPTION
### Motivation

- Provide an automated, configurable burn-in profile to exercise representative routing traffic over multi-hour runs to detect long-running stability issues. 
- Collect per-process memory trends for the router and workers to detect monotonic/unbounded growth before production rollout. 
- Validate resilience to transient worker failures and ensure continued message flow and recovery behavior under intermittent degradation.

### Description

- Add `PipoSupervisor.BurnIn` which runs a publisher loop, samples per-process memory (`Router` + workers), captures degraded/restored transitions and evaluates guardrails for memory growth, deadlock/livelock, and message-flow/recovery. 
- Implement an internal `BurnInWorker` that simulates stable and flaky subscribers and exposes `set_failure/2` to toggle transient failures. 
- Add a CLI task `mix pipo.burn_in` to run the profile with CLI flags (e.g. `--duration-hours`, `--sample-interval-ms`, `--publish-interval-ms`, `--growth-limit-mb`, `--max-stall-ms`, `--min-delivery-ratio`) and print a structured pass/fail report. 
- Add ExUnit tests (`PipoSupervisor.BurnInTest`) covering a short successful burn-in run and a failing strict delivery-ratio scenario, and add `docs/burn_in.md` describing traffic model, collected signals, and pass/fail criteria.

### Testing

- Ran `mix format` in `apps/pipo_supervisor` without errors. 
- Ran `cd apps/pipo_supervisor && mix test`; the added tests executed and passed (short passing burn-in run and strict-ratio failure case were exercised). 
- Tests exercise both the successful guardrail path and the failure path for an unachievable delivery ratio to validate guardrail logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60df560448331841f1ce67fa91198)