### PR TITLE
Add Go module and CLI compatibility scaffold for pipo

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,9 +13,30 @@ __/\\\\\\\\\\\\\____/\\\\\\\\\\\__/\\\\\\\\\\\\\_________/\\\\\______
 
 Pipo is the discord bot ever made.
 
-** Setup
+** Build and run
+*** Rust (legacy)
 #+BEGIN_SRC bash
-cargo run
+cargo run -- path-to-config.json path-to-db.sqlite3
+#+END_SRC
+
+You can also provide the paths via environment variables:
+
+#+BEGIN_SRC bash
+CONFIG_PATH=path-to-config.json DB_PATH=path-to-db.sqlite3 cargo run
+#+END_SRC
+
+*** Go rewrite branch workflow
+The Go rewrite currently focuses on CLI compatibility (argument/env parsing and usage output).
+
+#+BEGIN_SRC bash
+# Build the Go binary
+go build -o pipo-go ./cmd/pipo
+
+# Run with positional args
+./pipo-go path-to-config.json path-to-db.sqlite3
+
+# Or run with environment-variable fallback
+CONFIG_PATH=path-to-config.json DB_PATH=path-to-db.sqlite3 ./pipo-go
 #+END_SRC
 
 ** Tasks

--- a/cmd/pipo/main.go
+++ b/cmd/pipo/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args, os.Getenv); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, getenv func(string) string) error {
+	configPath, dbPath := resolvePaths(args, getenv)
+	if configPath == "" || dbPath == "" {
+		binaryName := "pipo"
+		if len(args) > 0 && args[0] != "" {
+			binaryName = args[0]
+		}
+
+		fmt.Printf("Usage: %s path-to-config.json [path-to-db.sqlite3]\n", binaryName)
+		return nil
+	}
+
+	return errors.New("Go rewrite runtime is not implemented yet")
+}
+
+func resolvePaths(args []string, getenv func(string) string) (string, string) {
+	var configPath string
+	if len(args) > 1 {
+		configPath = args[1]
+	}
+	if configPath == "" {
+		configPath = getenv("CONFIG_PATH")
+	}
+
+	var dbPath string
+	if len(args) > 2 {
+		dbPath = args[2]
+	}
+	if dbPath == "" {
+		dbPath = getenv("DB_PATH")
+	}
+
+	return configPath, dbPath
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/nemored/pipo
+
+go 1.22


### PR DESCRIPTION
### Motivation
- Provide a Go rewrite entrypoint while preserving existing CLI semantics so tools and scripts that invoke `pipo` keep working.
- Support the same positional-arg order as the Rust binary and allow environment-variable fallbacks for `CONFIG_PATH` and `DB_PATH`.

### Description
- Add a root `go.mod` (`module github.com/nemored/pipo`) to enable standard Go tooling for the rewrite branch.
- Implement `cmd/pipo/main.go` which parses positional args in Rust-compatible order, falls back to `CONFIG_PATH`/`DB_PATH`, emits the same usage text when required args are missing, and returns a non-zero error when runtime is not yet implemented.
- Update `README.org` to document both the Rust (legacy) `cargo run -- path-to-config.json path-to-db.sqlite3` workflow and the Go rewrite workflow with build/run examples (`go build ./cmd/pipo`, `./pipo-go` and env-var examples).

### Testing
- Ran `gofmt -w cmd/pipo/main.go` successfully to format the file.
- Built the Go binary with `go build ./cmd/pipo` which completed successfully.
- Verified `go run ./cmd/pipo` prints the usage text and exits with success (expected when args/env missing).
- Verified `CONFIG_PATH=a DB_PATH=b go run ./cmd/pipo` returns a non-zero exit with the placeholder "Go rewrite runtime is not implemented yet" error (expected behavior for the scaffold).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ac1d0b3c833188e2aeee14412913)