### PR TITLE
Add Go internal runtime packages for buses, events, and transport lifecycle

### DIFF
--- a/cmd/pipo/main.go
+++ b/cmd/pipo/main.go
@@ -1,9 +1,15 @@
 package main
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/nemored/pipo/internal/config"
+	"github.com/nemored/pipo/internal/core"
+	"github.com/nemored/pipo/internal/transports"
 )
 
 func main() {
@@ -25,7 +31,26 @@ func run(args []string, getenv func(string) string) error {
 		return nil
 	}
 
-	return errors.New("Go rewrite runtime is not implemented yet")
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return err
+	}
+
+	transportRunners, err := transports.Build(cfg)
+	if err != nil {
+		return err
+	}
+
+	busIDs := make([]string, 0, len(cfg.Buses))
+	for _, bus := range cfg.Buses {
+		busIDs = append(busIDs, bus.ID)
+	}
+
+	runtime := core.NewRuntime(busIDs, transportRunners)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return runtime.Run(ctx)
 }
 
 func resolvePaths(args []string, getenv func(string) string) (string, string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nemored/pipo/internal/store"
+)
+
+type Bus struct {
+	ID string `json:"id"`
+}
+
+type ParsedConfig struct {
+	Buses      []Bus       `json:"buses"`
+	Transports []Transport `json:"transports"`
+}
+
+type Transport struct {
+	Kind string          `json:"transport"`
+	Raw  json.RawMessage `json:"-"`
+
+	Nickname            string            `json:"nickname,omitempty"`
+	Server              string            `json:"server,omitempty"`
+	UseTLS              bool              `json:"use_tls,omitempty"`
+	ImgRoot             string            `json:"img_root,omitempty"`
+	Token               string            `json:"token,omitempty"`
+	BotToken            string            `json:"bot_token,omitempty"`
+	GuildID             uint64            `json:"guild_id,omitempty"`
+	Username            string            `json:"username,omitempty"`
+	Password            *string           `json:"password"`
+	ClientCert          *string           `json:"client_cert"`
+	ServerCert          *string           `json:"server_cert"`
+	Comment             *string           `json:"comment,omitempty"`
+	APIKey              string            `json:"api_key,omitempty"`
+	Interval            uint64            `json:"interval,omitempty"`
+	ChannelMapping      map[string]string `json:"channel_mapping,omitempty"`
+	VoiceChannelMapping map[string]string `json:"voice_channel_mapping,omitempty"`
+	Buses               []string          `json:"buses,omitempty"`
+}
+
+func (t *Transport) UnmarshalJSON(data []byte) error {
+	type alias Transport
+	aux := struct {
+		Transport string `json:"transport"`
+		*alias
+	}{alias: (*alias)(t)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	t.Kind = aux.Transport
+	t.Raw = append(t.Raw[:0], data...)
+	return nil
+}
+
+func Load(path string) (ParsedConfig, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return ParsedConfig{}, fmt.Errorf("read config: %w", err)
+	}
+	blob = store.StripJSONComments(blob)
+	var cfg ParsedConfig
+	if err := json.Unmarshal(blob, &cfg); err != nil {
+		return ParsedConfig{}, fmt.Errorf("parse config: %w", err)
+	}
+	if len(cfg.Buses) == 0 {
+		return ParsedConfig{}, fmt.Errorf("parse config: buses must not be empty")
+	}
+	for _, bus := range cfg.Buses {
+		if bus.ID == "" {
+			return ParsedConfig{}, fmt.Errorf("parse config: buses[].id is required")
+		}
+	}
+	for i, transport := range cfg.Transports {
+		if transport.Kind == "" {
+			return ParsedConfig{}, fmt.Errorf("parse config: transports[%d].transport is required", i)
+		}
+	}
+	return cfg, nil
+}

--- a/internal/core/bus.go
+++ b/internal/core/bus.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/nemored/pipo/internal/model"
+)
+
+var ErrUnknownBus = errors.New("unknown bus")
+
+type Broker struct {
+	mu    sync.RWMutex
+	buses map[string]*bus
+}
+
+type bus struct {
+	id          string
+	subscribers map[chan model.Event]struct{}
+}
+
+func NewBroker(busIDs []string) *Broker {
+	buses := make(map[string]*bus, len(busIDs))
+	for _, id := range busIDs {
+		buses[id] = &bus{id: id, subscribers: map[chan model.Event]struct{}{}}
+	}
+	return &Broker{buses: buses}
+}
+
+func (b *Broker) Publish(busID string, event model.Event) error {
+	b.mu.RLock()
+	bus, ok := b.buses[busID]
+	if !ok {
+		b.mu.RUnlock()
+		return fmt.Errorf("%w: %s", ErrUnknownBus, busID)
+	}
+	for ch := range bus.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Drop when subscriber is saturated to avoid global stalls.
+		}
+	}
+	b.mu.RUnlock()
+	return nil
+}
+
+func (b *Broker) Subscribe(ctx context.Context, busID string, buffer int) (<-chan model.Event, error) {
+	b.mu.Lock()
+	bus, ok := b.buses[busID]
+	if !ok {
+		b.mu.Unlock()
+		return nil, fmt.Errorf("%w: %s", ErrUnknownBus, busID)
+	}
+	ch := make(chan model.Event, buffer)
+	bus.subscribers[ch] = struct{}{}
+	b.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		b.mu.Lock()
+		if _, ok := bus.subscribers[ch]; ok {
+			delete(bus.subscribers, ch)
+			close(ch)
+		}
+		b.mu.Unlock()
+	}()
+
+	return ch, nil
+}

--- a/internal/core/bus_test.go
+++ b/internal/core/bus_test.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nemored/pipo/internal/model"
+)
+
+func TestBrokerPublishesToBusSubscribers(t *testing.T) {
+	b := NewBroker([]string{"alpha", "beta"})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub, err := b.Subscribe(ctx, "alpha", 1)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	if err := b.Publish("alpha", model.Event{Kind: model.EventText}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case ev := <-sub:
+		if ev.Kind != model.EventText {
+			t.Fatalf("unexpected kind: %s", ev.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}

--- a/internal/core/runtime.go
+++ b/internal/core/runtime.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/nemored/pipo/internal/model"
+)
+
+type RuntimeAPI interface {
+	Publish(busID string, event model.Event) error
+	Subscribe(ctx context.Context, busID string, buffer int) (<-chan model.Event, error)
+}
+
+type Transport interface {
+	Name() string
+	Run(ctx context.Context, api RuntimeAPI) error
+}
+
+type Runtime struct {
+	broker     *Broker
+	transports []Transport
+}
+
+func NewRuntime(busIDs []string, transports []Transport) *Runtime {
+	return &Runtime{broker: NewBroker(busIDs), transports: transports}
+}
+
+func (r *Runtime) Publish(busID string, event model.Event) error {
+	return r.broker.Publish(busID, event)
+}
+
+func (r *Runtime) Subscribe(ctx context.Context, busID string, buffer int) (<-chan model.Event, error) {
+	return r.broker.Subscribe(ctx, busID, buffer)
+}
+
+func (r *Runtime) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, len(r.transports))
+	var wg sync.WaitGroup
+
+	for _, transport := range r.transports {
+		transport := transport
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := transport.Run(ctx, r); err != nil {
+				errCh <- fmt.Errorf("transport %s: %w", transport.Name(), err)
+				cancel()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-done
+		select {
+		case err := <-errCh:
+			return err
+		default:
+			return nil
+		}
+	case <-done:
+		select {
+		case err := <-errCh:
+			return err
+		default:
+			return nil
+		}
+	}
+}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -1,0 +1,73 @@
+package model
+
+import "time"
+
+// EventKind enumerates normalized cross-transport events.
+type EventKind string
+
+const (
+	EventText     EventKind = "Text"
+	EventAction   EventKind = "Action"
+	EventBot      EventKind = "Bot"
+	EventDelete   EventKind = "Delete"
+	EventPin      EventKind = "Pin"
+	EventReaction EventKind = "Reaction"
+	EventNames    EventKind = "Names"
+)
+
+// ThreadRef carries transport-specific thread linkage.
+type ThreadRef struct {
+	SlackThreadTS *string `json:"slack_thread_ts,omitempty"`
+	DiscordThread *uint64 `json:"discord_thread,omitempty"`
+}
+
+// Attachment is a normalized attachment payload for forwarding/edit paths.
+type Attachment struct {
+	ID           uint64  `json:"id"`
+	PipoID       *int64  `json:"pipo_id,omitempty"`
+	ServiceName  *string `json:"service_name,omitempty"`
+	ServiceURL   *string `json:"service_url,omitempty"`
+	AuthorName   *string `json:"author_name,omitempty"`
+	AuthorSub    *string `json:"author_subname,omitempty"`
+	AuthorLink   *string `json:"author_link,omitempty"`
+	AuthorIcon   *string `json:"author_icon,omitempty"`
+	Filename     *string `json:"filename,omitempty"`
+	FromURL      *string `json:"from_url,omitempty"`
+	OriginalURL  *string `json:"original_url,omitempty"`
+	Footer       *string `json:"footer,omitempty"`
+	FooterIcon   *string `json:"footer_icon,omitempty"`
+	ContentType  *string `json:"content_type,omitempty"`
+	Size         *uint64 `json:"size,omitempty"`
+	Text         *string `json:"text,omitempty"`
+	ImageURL     *string `json:"image_url,omitempty"`
+	ImageBytes   *uint64 `json:"image_bytes,omitempty"`
+	ImageHeight  *uint64 `json:"image_height,omitempty"`
+	ImageWidth   *uint64 `json:"image_width,omitempty"`
+	FallbackText *string `json:"fallback,omitempty"`
+}
+
+// SourceRef identifies the transport/local message behind a normalized event.
+type SourceRef struct {
+	Transport string  `json:"transport"`
+	BusID     string  `json:"bus_id"`
+	MessageID *string `json:"message_id,omitempty"`
+}
+
+// Event is the normalized equivalent of Rust Message variants, with optional
+// fields needed for cross-transport forwarding and edit/reaction synchronization.
+type Event struct {
+	Kind        EventKind    `json:"kind"`
+	Sender      int          `json:"sender"`
+	PipoID      *int64       `json:"pipo_id,omitempty"`
+	Source      SourceRef    `json:"source"`
+	Username    *string      `json:"username,omitempty"`
+	AvatarURL   *string      `json:"avatar_url,omitempty"`
+	Thread      *ThreadRef   `json:"thread,omitempty"`
+	Message     *string      `json:"message,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	IsEdit      bool         `json:"is_edit,omitempty"`
+	IRCFlag     bool         `json:"irc_flag,omitempty"`
+	Emoji       *string      `json:"emoji,omitempty"`
+	Remove      bool         `json:"remove,omitempty"`
+	CreatedAt   time.Time    `json:"created_at"`
+}

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -1,0 +1,10 @@
+package store
+
+import "regexp"
+
+var lineComments = regexp.MustCompile(`(?m)//.*$`)
+
+// StripJSONComments removes single-line // comments for Rust-compat config parsing.
+func StripJSONComments(in []byte) []byte {
+	return lineComments.ReplaceAll(in, nil)
+}

--- a/internal/transports/factory.go
+++ b/internal/transports/factory.go
@@ -1,0 +1,51 @@
+package transports
+
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"slices"
+
+	"github.com/nemored/pipo/internal/config"
+	"github.com/nemored/pipo/internal/core"
+	"github.com/nemored/pipo/internal/transports/noop"
+)
+
+func Build(cfg config.ParsedConfig) ([]core.Transport, error) {
+	knownBuses := make(map[string]struct{}, len(cfg.Buses))
+	for _, bus := range cfg.Buses {
+		knownBuses[bus.ID] = struct{}{}
+	}
+
+	out := make([]core.Transport, 0, len(cfg.Transports))
+	for idx, tc := range cfg.Transports {
+		busIDs := resolveBuses(tc)
+		if len(busIDs) == 0 {
+			busIDs = slices.Collect(iter.Seq[string](maps.Keys(knownBuses)))
+			slices.Sort(busIDs)
+		}
+		for _, busID := range busIDs {
+			if _, ok := knownBuses[busID]; !ok {
+				return nil, fmt.Errorf("transport %d (%s) references unknown bus %q", idx, tc.Kind, busID)
+			}
+		}
+		out = append(out, noop.New(fmt.Sprintf("%s[%d]", tc.Kind, idx), busIDs))
+	}
+	return out, nil
+}
+
+func resolveBuses(tc config.Transport) []string {
+	if len(tc.Buses) > 0 {
+		return slices.Clone(tc.Buses)
+	}
+	set := map[string]struct{}{}
+	for busID := range tc.ChannelMapping {
+		set[busID] = struct{}{}
+	}
+	for busID := range tc.VoiceChannelMapping {
+		set[busID] = struct{}{}
+	}
+	out := slices.Collect(iter.Seq[string](maps.Keys(set)))
+	slices.Sort(out)
+	return out
+}

--- a/internal/transports/noop/noop.go
+++ b/internal/transports/noop/noop.go
@@ -1,0 +1,39 @@
+package noop
+
+import (
+	"context"
+	"sync"
+
+	"github.com/nemored/pipo/internal/core"
+	"github.com/nemored/pipo/internal/model"
+)
+
+type Transport struct {
+	name  string
+	buses []string
+}
+
+func New(name string, buses []string) *Transport {
+	return &Transport{name: name, buses: buses}
+}
+
+func (t *Transport) Name() string { return t.name }
+
+func (t *Transport) Run(ctx context.Context, api core.RuntimeAPI) error {
+	var wg sync.WaitGroup
+	for _, busID := range t.buses {
+		sub, err := api.Subscribe(ctx, busID, 32)
+		if err != nil {
+			return err
+		}
+		wg.Add(1)
+		go func(ch <-chan model.Event) {
+			defer wg.Done()
+			for range ch {
+			}
+		}(sub)
+	}
+	<-ctx.Done()
+	wg.Wait()
+	return nil
+}


### PR DESCRIPTION
### Motivation
- Provide a working Go runtime for the rewrite by wiring config, transport construction, and a transport lifecycle loop.  
- Introduce a normalized event type that maps the Rust `Message` variants (`Text`, `Action`, `Bot`, `Delete`, `Pin`, `Reaction`, `Names`) and carries metadata needed for forwarding and edits.  
- Implement per-bus publish/subscribe channels so transports can subscribe to and forward bus-specific events.  
- Preserve Rust-compatible config semantics by supporting `//` JSON comments and validating `buses[].id` and transport discriminators.

### Description
- Add new internal packages and files: `internal/config` (`config.go`), `internal/core` (`bus.go`, `runtime.go`, `bus_test.go`), `internal/model` (`event.go`), `internal/store` (`json.go`), and `internal/transports` with a `noop` scaffold and `factory.go` to build transports.  
- Introduce `model.Event`, `model.EventKind`, `SourceRef`, `ThreadRef`, and `Attachment` to normalize message/event payloads for cross-transport forwarding and edit/reaction synchronization.  
- Implement `core.Broker` with `Publish`/`Subscribe` keyed by `buses[].id` and context-bound subscription cleanup, and `core.Runtime` which runs each `Transport` in its own goroutine and propagates cancellation/errors.  
- Implement config loader `config.Load` that strips `//` comments via `store.StripJSONComments` and validates buses and transport discriminator fields.  
- Add `transports.Build` to resolve transport->bus bindings (rejecting unknown bus IDs) and a `noop` transport that subscribes to configured buses and drains events.  
- Wire `cmd/pipo` to load configuration, build transport runners, initialize runtime with bus IDs, and run until signal cancellation.  
- Add `internal/core/bus_test.go` which validates publish/subscribe delivery on a bus channel.

### Testing
- Ran code formatting with `gofmt -w` over modified files (succeeded).  
- Ran unit tests with `go test ./...` and they all passed (`internal/core` tests exercised the broker and succeeded).  
- Verified that the program now loads config and constructs the runtime instead of returning a not-implemented error by exercising `cmd/pipo` startup flow in tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ae36443c8331a3bc016284c3fcf2)