### PR TITLE
Strict transport config parsing (Rust-compatible) and config migration CLI

### DIFF
--- a/cmd/pipo-config-migrate/main.go
+++ b/cmd/pipo-config-migrate/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/nemored/pipo/internal/config"
+)
+
+func main() {
+	var in string
+	flag.StringVar(&in, "in", "", "path to the config file to migrate")
+	flag.Parse()
+
+	if in == "" {
+		fmt.Fprintln(os.Stderr, "usage: pipo-config-migrate --in path-to-config.json")
+		os.Exit(2)
+	}
+
+	backup, err := migrateConfig(in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "migration failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Migration complete. Backup written to %s\n", backup)
+}
+
+func migrateConfig(path string) (string, error) {
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read config: %w", err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		return "", fmt.Errorf("validate current schema: %w", err)
+	}
+
+	backup := fmt.Sprintf("%s.bak.%s", path, time.Now().UTC().Format("20060102T150405Z"))
+	if err := os.WriteFile(backup, original, 0o600); err != nil {
+		return "", fmt.Errorf("write backup: %w", err)
+	}
+
+	normalized, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal normalized config: %w", err)
+	}
+	normalized = append(normalized, '\n')
+	if err := os.WriteFile(path, normalized, 0o600); err != nil {
+		return "", fmt.Errorf("write migrated config: %w", err)
+	}
+
+	if _, err := os.Stat(backup); err != nil {
+		return "", errors.New("backup file missing after migration")
+	}
+	return filepath.Clean(backup), nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/nemored/pipo/internal/store"
 )
@@ -41,16 +44,11 @@ type Transport struct {
 }
 
 func (t *Transport) UnmarshalJSON(data []byte) error {
-	type alias Transport
-	aux := struct {
-		Transport string `json:"transport"`
-		*alias
-	}{alias: (*alias)(t)}
-	if err := json.Unmarshal(data, &aux); err != nil {
+	tt, err := decodeTransport(data, -1)
+	if err != nil {
 		return err
 	}
-	t.Kind = aux.Transport
-	t.Raw = append(t.Raw[:0], data...)
+	*t = tt
 	return nil
 }
 
@@ -60,22 +58,200 @@ func Load(path string) (ParsedConfig, error) {
 		return ParsedConfig{}, fmt.Errorf("read config: %w", err)
 	}
 	blob = store.StripJSONComments(blob)
-	var cfg ParsedConfig
-	if err := json.Unmarshal(blob, &cfg); err != nil {
+
+	top := struct {
+		Buses      []Bus             `json:"buses"`
+		Transports []json.RawMessage `json:"transports"`
+	}{}
+	if err := decodeStrict(blob, &top); err != nil {
 		return ParsedConfig{}, fmt.Errorf("parse config: %w", err)
 	}
-	if len(cfg.Buses) == 0 {
+	if len(top.Buses) == 0 {
 		return ParsedConfig{}, fmt.Errorf("parse config: buses must not be empty")
 	}
-	for _, bus := range cfg.Buses {
+	for i, bus := range top.Buses {
 		if bus.ID == "" {
-			return ParsedConfig{}, fmt.Errorf("parse config: buses[].id is required")
+			return ParsedConfig{}, fmt.Errorf("parse config: buses[%d].id is required", i)
 		}
 	}
-	for i, transport := range cfg.Transports {
-		if transport.Kind == "" {
-			return ParsedConfig{}, fmt.Errorf("parse config: transports[%d].transport is required", i)
+
+	cfg := ParsedConfig{Buses: top.Buses, Transports: make([]Transport, 0, len(top.Transports))}
+	for i, raw := range top.Transports {
+		transport, err := decodeTransport(raw, i)
+		if err != nil {
+			return ParsedConfig{}, err
 		}
+		cfg.Transports = append(cfg.Transports, transport)
 	}
 	return cfg, nil
+}
+
+func decodeTransport(raw []byte, index int) (Transport, error) {
+	prefix := "parse config"
+	if index >= 0 {
+		prefix = fmt.Sprintf("parse config: transports[%d]", index)
+	}
+
+	tag := struct {
+		Kind string `json:"transport"`
+	}{}
+	if err := json.Unmarshal(raw, &tag); err != nil {
+		return Transport{}, fmt.Errorf("%s: invalid transport block: %w", prefix, err)
+	}
+	if tag.Kind == "" {
+		return Transport{}, fmt.Errorf("%s: transport is required", prefix)
+	}
+
+	t := Transport{Kind: tag.Kind, Raw: append(json.RawMessage(nil), raw...)}
+	fields, err := parseObject(raw)
+	if err != nil {
+		return Transport{}, fmt.Errorf("%s: invalid transport block: %w", prefix, err)
+	}
+
+	switch tag.Kind {
+	case "IRC":
+		var cfg struct {
+			Kind           string            `json:"transport"`
+			Nickname       string            `json:"nickname"`
+			Server         string            `json:"server"`
+			UseTLS         bool              `json:"use_tls"`
+			ImgRoot        string            `json:"img_root"`
+			ChannelMapping map[string]string `json:"channel_mapping"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (IRC): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{"nickname": false, "server": false, "use_tls": false, "img_root": false, "channel_mapping": false}); err != nil {
+			return Transport{}, fmt.Errorf("%s (IRC): %w", prefix, err)
+		}
+		t.Nickname, t.Server, t.UseTLS, t.ImgRoot, t.ChannelMapping = cfg.Nickname, cfg.Server, cfg.UseTLS, cfg.ImgRoot, cfg.ChannelMapping
+	case "Discord":
+		var cfg struct {
+			Kind           string            `json:"transport"`
+			Token          string            `json:"token"`
+			GuildID        uint64            `json:"guild_id"`
+			ChannelMapping map[string]string `json:"channel_mapping"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (Discord): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{"token": false, "guild_id": false, "channel_mapping": false}); err != nil {
+			return Transport{}, fmt.Errorf("%s (Discord): %w", prefix, err)
+		}
+		t.Token, t.GuildID, t.ChannelMapping = cfg.Token, cfg.GuildID, cfg.ChannelMapping
+	case "Slack":
+		var cfg struct {
+			Kind           string            `json:"transport"`
+			Token          string            `json:"token"`
+			BotToken       string            `json:"bot_token"`
+			ChannelMapping map[string]string `json:"channel_mapping"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (Slack): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{"token": false, "bot_token": false, "channel_mapping": false}); err != nil {
+			return Transport{}, fmt.Errorf("%s (Slack): %w", prefix, err)
+		}
+		t.Token, t.BotToken, t.ChannelMapping = cfg.Token, cfg.BotToken, cfg.ChannelMapping
+	case "Minecraft":
+		var cfg struct {
+			Kind     string   `json:"transport"`
+			Username string   `json:"username"`
+			Buses    []string `json:"buses"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (Minecraft): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{"username": false, "buses": false}); err != nil {
+			return Transport{}, fmt.Errorf("%s (Minecraft): %w", prefix, err)
+		}
+		t.Username, t.Buses = cfg.Username, cfg.Buses
+	case "Mumble":
+		var cfg struct {
+			Kind                string            `json:"transport"`
+			Server              string            `json:"server"`
+			Password            *string           `json:"password"`
+			Nickname            string            `json:"nickname"`
+			ClientCert          *string           `json:"client_cert"`
+			ServerCert          *string           `json:"server_cert"`
+			Comment             *string           `json:"comment,omitempty"`
+			ChannelMapping      map[string]string `json:"channel_mapping"`
+			VoiceChannelMapping map[string]string `json:"voice_channel_mapping"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (Mumble): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{
+			"server": false, "password": true, "nickname": false, "client_cert": true,
+			"server_cert": true, "channel_mapping": false, "voice_channel_mapping": false,
+		}); err != nil {
+			return Transport{}, fmt.Errorf("%s (Mumble): %w", prefix, err)
+		}
+		t.Server, t.Password, t.Nickname, t.ClientCert, t.ServerCert, t.Comment = cfg.Server, cfg.Password, cfg.Nickname, cfg.ClientCert, cfg.ServerCert, cfg.Comment
+		t.ChannelMapping, t.VoiceChannelMapping = cfg.ChannelMapping, cfg.VoiceChannelMapping
+	case "Rachni":
+		var cfg struct {
+			Kind     string   `json:"transport"`
+			Server   string   `json:"server"`
+			APIKey   string   `json:"api_key"`
+			Interval uint64   `json:"interval"`
+			Buses    []string `json:"buses"`
+		}
+		if err := decodeStrict(raw, &cfg); err != nil {
+			return Transport{}, fmt.Errorf("%s (Rachni): %w", prefix, err)
+		}
+		if err := requireFields(fields, map[string]bool{"server": false, "api_key": false, "interval": false, "buses": false}); err != nil {
+			return Transport{}, fmt.Errorf("%s (Rachni): %w", prefix, err)
+		}
+		t.Server, t.APIKey, t.Interval, t.Buses = cfg.Server, cfg.APIKey, cfg.Interval, cfg.Buses
+	default:
+		return Transport{}, fmt.Errorf("%s: unsupported transport %q (expected one of IRC, Discord, Slack, Minecraft, Mumble, Rachni)", prefix, tag.Kind)
+	}
+
+	return t, nil
+}
+
+func decodeStrict(data []byte, target any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(target); err != nil {
+		return err
+	}
+	if dec.More() {
+		return fmt.Errorf("unexpected trailing JSON content")
+	}
+	return nil
+}
+
+func parseObject(raw []byte) (map[string]json.RawMessage, error) {
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	return out, nil
+}
+
+func requireFields(fields map[string]json.RawMessage, required map[string]bool) error {
+	for key, nullable := range required {
+		v, ok := fields[key]
+		if !ok {
+			if nullable {
+				return fmt.Errorf("field %q is required (use null when unset)", key)
+			}
+			return fmt.Errorf("field %q is required", key)
+		}
+		if !nullable && strings.TrimSpace(string(v)) == "null" {
+			return fmt.Errorf("field %q cannot be null", key)
+		}
+	}
+	return nil
+}
+
+func SupportedTransportKinds() []string {
+	kinds := []string{"IRC", "Discord", "Slack", "Minecraft", "Mumble", "Rachni"}
+	sort.Strings(kinds)
+	return kinds
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return p
+}
+
+func TestLoadSupportsAllTransportsAndComments(t *testing.T) {
+	path := writeConfig(t, `{
+// top-level comment
+"buses": [{"id": "main"}],
+"transports": [
+  {"transport":"IRC","nickname":"n","server":"s","use_tls":true,"img_root":"i","channel_mapping":{"main":"#chan"}},
+  {"transport":"Discord","token":"t","guild_id":1,"channel_mapping":{"main":"1"}},
+  {"transport":"Slack","token":"t","bot_token":"b","channel_mapping":{"main":"C1"}},
+  {"transport":"Minecraft","username":"steve","buses":["main"]},
+  {"transport":"Mumble","server":"m","password":null,"nickname":"pipo","client_cert":null,"server_cert":null,
+   "channel_mapping":{"main":"text"},"voice_channel_mapping":{"main":"voice"}},
+  {"transport":"Rachni","server":"r","api_key":"k","interval":10,"buses":["main"]}
+]// trailing comment
+}`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(cfg.Transports) != 6 {
+		t.Fatalf("expected 6 transports, got %d", len(cfg.Transports))
+	}
+	if cfg.Transports[0].ChannelMapping["main"] != "#chan" {
+		t.Fatalf("expected channel mapping to be preserved")
+	}
+	if cfg.Transports[4].VoiceChannelMapping["main"] != "voice" {
+		t.Fatalf("expected voice mapping to be preserved")
+	}
+}
+
+func TestLoadValidationMessagesPerTransport(t *testing.T) {
+	path := writeConfig(t, `{
+"buses": [{"id": "main"}],
+"transports": [
+  {"transport":"Mumble","server":"m","nickname":"pipo","client_cert":null,"server_cert":null,
+   "channel_mapping":{"main":"text"},"voice_channel_mapping":{"main":"voice"}}
+]
+}`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := err.Error(); !strings.Contains(got, `transports[0] (Mumble): field "password" is required`) {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestLoadRejectsUnknownTransportField(t *testing.T) {
+	path := writeConfig(t, `{
+"buses": [{"id": "main"}],
+"transports": [
+  {"transport":"IRC","nickname":"n","server":"s","use_tls":true,"img_root":"i","channel_mapping":{"main":"#chan"},"extra":1}
+]
+}`)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if got := err.Error(); !strings.Contains(got, `transports[0] (IRC): json: unknown field "extra"`) {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -2,7 +2,8 @@ package store
 
 import "regexp"
 
-var lineComments = regexp.MustCompile(`(?m)//.*$`)
+// Matches Rust's config comment stripping regex: //[^\n\r]*
+var lineComments = regexp.MustCompile(`//[^\n\r]*`)
 
 // StripJSONComments removes single-line // comments for Rust-compat config parsing.
 func StripJSONComments(in []byte) []byte {


### PR DESCRIPTION
### Motivation
- Ensure the Go rewrite accepts the same tagged `transport` schema as the Rust `ConfigTransport` enum and preserve existing map/list structures used for channel/bus mappings. 
- Provide stricter, actionable validation errors per `transports[i]` block to make configuration problems easy to locate and fix. 
- Preserve current behavior of stripping `//` single-line comments before JSON decode and add a migration tool to safely evolve on-disk configs.

### Description
- Implement per-transport decoding and validation via `decodeTransport`, `decodeStrict`, and `requireFields`, enforcing the `transport` discriminator and variant-specific required/nullable fields for `IRC`, `Discord`, `Slack`, `Minecraft`, `Mumble`, and `Rachni`. 
- Preserve `channel_mapping`, `voice_channel_mapping`, and `buses` structures and retain raw transport JSON on each parsed `Transport` (`Raw`). 
- Update comment stripping regex to match Rust semantics (`//[^\n\r]*`) in `store.StripJSONComments`. 
- Replace the simple `json.Unmarshal` path with strict parsing of the top-level object and per-transport blocks to reject unknown fields and return precise error messages of the form `parse config: transports[N] (Kind): ...` or `parse config: buses[M].id is required`. 
- Add a migration CLI `cmd/pipo-config-migrate` that validates a config, writes a timestamped backup (`<path>.bak.<UTC>`), and rewrites a normalized, indented JSON file to support future schema migrations. 
- Add unit tests (`internal/config/config_test.go`) that check comment stripping, preservation of mappings, per-transport validation messages, and unknown-field rejection.

### Testing
- Added unit tests in `internal/config/config_test.go` and ran `go test ./...`, which succeeded. 
- Existing store tests continue to pass and the new config tests validate the strict parsing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b4f0dc788331ba9aa7053d3cc372)