### PR TITLE
Add Go transport adapter scaffolding and per-transport parity docs

### DIFF
--- a/cmd/pipo/main.go
+++ b/cmd/pipo/main.go
@@ -59,7 +59,7 @@ func run(args []string, getenv func(string) string) error {
 		return err
 	}
 
-	transportRunners, err := transports.Build(cfg)
+	transportRunners, err := transports.Build(cfg, s)
 	if err != nil {
 		return err
 	}

--- a/docs/parity/discord.md
+++ b/docs/parity/discord.md
@@ -1,0 +1,13 @@
+# Discord parity (Rust -> Go)
+
+## Completed
+- Added a dedicated Discord adapter in factory wiring.
+- Adapter now uses common connect/reconnect lifecycle scaffold.
+- Preserved channel mapping semantics in adapter state.
+
+## Pending
+- Gateway lifecycle/session resumption parity.
+- Guild/channel bootstrap and channel ID mapping from config.
+- Message create/edit/delete/reaction parity bound to shared `pipo_id` and SQLite mapping queries.
+- Attachment/embed translation parity.
+- Discord thread and reply behavior parity.

--- a/docs/parity/irc.md
+++ b/docs/parity/irc.md
@@ -1,0 +1,13 @@
+# IRC parity (Rust -> Go)
+
+## Completed
+- Added dedicated IRC adapter wiring in factory.
+- Adapter has reconnect lifecycle scaffold consistent with Rust transport lifecycle expectations.
+- Preserved channel mapping representation for bus<->channel routing.
+
+## Pending
+- IRC socket/TLS connection and registration lifecycle.
+- Join/part/names handling parity.
+- CTCP action mapping parity.
+- Edit/delete/reaction compatibility paths (where represented through normalized events).
+- DB interactions for `pipo_id` allocation and lookup on IRC-originated messages.

--- a/docs/parity/minecraft.md
+++ b/docs/parity/minecraft.md
@@ -1,0 +1,7 @@
+# Minecraft parity (Rust -> Go)
+
+## Completed
+- Kept transport in explicit not-implemented status, matching Rust TODO intent.
+
+## Pending
+- All runtime behavior remains intentionally unimplemented.

--- a/docs/parity/mumble.md
+++ b/docs/parity/mumble.md
@@ -1,0 +1,13 @@
+# Mumble parity (Rust -> Go)
+
+## Completed
+- Added dedicated Mumble adapter wiring in factory.
+- Added lifecycle scaffold with reconnect support.
+- Preserved text channel mapping in adapter state and config parsing already includes voice mapping.
+
+## Pending
+- Full Mumble protocol client implementation.
+- Protobuf packet encode/decode integration from `protos/Mumble.proto`.
+- Voice channel mapping behavior parity.
+- Message/edit/delete/reaction parity tied to shared `pipo_id`.
+- Certificate handling parity (`client_cert` and `server_cert` behavior).

--- a/docs/parity/rachni.md
+++ b/docs/parity/rachni.md
@@ -1,0 +1,11 @@
+# Rachni parity (Rust -> Go)
+
+## Completed
+- Added dedicated Rachni adapter wiring and explicit `buses` routing usage.
+- Added lifecycle scaffold suitable for periodic polling + reconnect behavior.
+- Preserved Rust DB quirk with `InsertAllocatedIDRachni` returning post-increment value after insert.
+
+## Pending
+- Polling implementation against Rachni stream endpoint.
+- Start/stop stream detection parity and emitted action text parity.
+- Full event publication loop integration using shared runtime API.

--- a/docs/parity/slack.md
+++ b/docs/parity/slack.md
@@ -1,0 +1,13 @@
+# Slack parity (Rust -> Go)
+
+## Completed
+- Added a dedicated Slack adapter type in the transport factory (no longer generic noop), preserving transport naming/indexing.
+- Added reconnect-aware adapter lifecycle loop (`connect` + `session` with retry/backoff).
+- Preserved channel mapping semantics by maintaining bus->remote and reverse remote->bus maps in adapter state.
+
+## Pending
+- Slack RTM/WebSocket auth + event stream handling.
+- Slack users/channels hydration (`conversations.list`, user list caching).
+- Message forwarding parity: text/action/bot.
+- Edit/delete/reaction parity using shared `pipo_id` + DB lookup/update methods.
+- Threading semantics parity.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -109,6 +109,25 @@ func (s *SQLiteStore) InsertAllocatedID(ctx context.Context) (int64, error) {
 	return id, nil
 }
 
+// InsertAllocatedIDRachni preserves Rust's off-by-one return behavior for
+// Rachni: insert current id, increment shared counter, then return incremented value.
+func (s *SQLiteStore) InsertAllocatedIDRachni(ctx context.Context) (int64, error) {
+	s.mu.Lock()
+	id := s.nextID
+	s.nextID++
+	if s.nextID > maxPipoID {
+		s.nextID = 0
+	}
+	ret := s.nextID
+	s.mu.Unlock()
+
+	const q = `INSERT OR REPLACE INTO messages (id) VALUES (?1)`
+	if _, err := s.db.ExecContext(ctx, q, id); err != nil {
+		return 0, err
+	}
+	return ret, nil
+}
+
 func (s *SQLiteStore) InsertOrReplaceSlack(ctx context.Context, slackID string) (int64, error) {
 	id := s.allocID()
 	const q = `INSERT OR REPLACE INTO messages (id, slackid) VALUES (?1, ?2)`

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -103,3 +103,28 @@ func TestSeedFromLatestModtime(t *testing.T) {
 		t.Fatalf("expected next id from latest modtime row to be 8, got %d", next)
 	}
 }
+
+func TestInsertAllocatedIDRachniReturnsPostIncrementValue(t *testing.T) {
+	ctx := context.Background()
+	s, err := OpenSQLite(ctx, ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer s.Close()
+
+	got, err := s.InsertAllocatedIDRachni(ctx)
+	if err != nil {
+		t.Fatalf("insert rachni id: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected post-increment id 2, got %d", got)
+	}
+
+	var c int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages WHERE id = 1`).Scan(&c); err != nil {
+		t.Fatalf("count inserted id: %v", err)
+	}
+	if c != 1 {
+		t.Fatalf("expected inserted row with id=1")
+	}
+}

--- a/internal/transports/adapters.go
+++ b/internal/transports/adapters.go
@@ -1,0 +1,173 @@
+package transports
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/nemored/pipo/internal/config"
+	"github.com/nemored/pipo/internal/core"
+	"github.com/nemored/pipo/internal/model"
+	"github.com/nemored/pipo/internal/store"
+)
+
+var errReconnect = errors.New("reconnect requested")
+
+// transportAdapter captures parity-focused lifecycle and mapping behavior.
+type transportAdapter struct {
+	name            string
+	transportID     int
+	channelToRemote map[string]string
+	remoteToChannel map[string]string
+	buses           []string
+	store           *store.SQLiteStore
+	connectFn       func(context.Context) error
+	sessionFn       func(context.Context, core.RuntimeAPI) error
+}
+
+func (t *transportAdapter) Name() string { return t.name }
+
+func (t *transportAdapter) Run(ctx context.Context, api core.RuntimeAPI) error {
+	backoff := time.Second
+	for {
+		if err := t.connectFn(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			if !sleepWithContext(ctx, backoff) {
+				return nil
+			}
+			backoff = minDuration(backoff*2, 30*time.Second)
+			continue
+		}
+		backoff = time.Second
+		err := t.sessionFn(ctx, api)
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, errReconnect) {
+			if !sleepWithContext(ctx, time.Second) {
+				return nil
+			}
+			continue
+		}
+		return err
+	}
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func baseAdapter(kind string, idx int, tc config.Transport, s *store.SQLiteStore) *transportAdapter {
+	remoteToChannel := make(map[string]string, len(tc.ChannelMapping))
+	buses := make([]string, 0, len(tc.ChannelMapping))
+	for busID, remoteID := range tc.ChannelMapping {
+		buses = append(buses, busID)
+		remoteToChannel[remoteID] = busID
+	}
+	return &transportAdapter{
+		name:            fmt.Sprintf("%s[%d]", kind, idx),
+		transportID:     idx,
+		channelToRemote: cloneMap(tc.ChannelMapping),
+		remoteToChannel: remoteToChannel,
+		buses:           buses,
+		store:           s,
+		connectFn:       func(context.Context) error { return nil },
+		sessionFn:       consumeOnlySession(buses),
+	}
+}
+
+func cloneMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func consumeOnlySession(buses []string) func(context.Context, core.RuntimeAPI) error {
+	return func(ctx context.Context, api core.RuntimeAPI) error {
+		var wg sync.WaitGroup
+		for _, busID := range buses {
+			sub, err := api.Subscribe(ctx, busID, 64)
+			if err != nil {
+				return err
+			}
+			wg.Add(1)
+			go func(ch <-chan model.Event) {
+				defer wg.Done()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case _, ok := <-ch:
+						if !ok {
+							return
+						}
+					}
+				}
+			}(sub)
+		}
+		<-ctx.Done()
+		wg.Wait()
+		return nil
+	}
+}
+
+func buildSlack(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
+	t := baseAdapter("Slack", idx, tc, s)
+	t.connectFn = func(context.Context) error { return nil }
+	return t
+}
+
+func buildDiscord(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
+	t := baseAdapter("Discord", idx, tc, s)
+	t.connectFn = func(context.Context) error { return nil }
+	return t
+}
+
+func buildIRC(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
+	t := baseAdapter("IRC", idx, tc, s)
+	t.connectFn = func(context.Context) error { return nil }
+	return t
+}
+
+func buildMumble(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
+	t := baseAdapter("Mumble", idx, tc, s)
+	t.connectFn = func(context.Context) error { return nil }
+	return t
+}
+
+func buildRachni(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
+	t := baseAdapter("Rachni", idx, tc, s)
+	t.buses = append([]string(nil), tc.Buses...)
+	t.connectFn = func(context.Context) error { return nil }
+	return t
+}
+
+type notImplementedTransport struct{ name string }
+
+func (t notImplementedTransport) Name() string { return t.name }
+func (t notImplementedTransport) Run(context.Context, core.RuntimeAPI) error {
+	return errors.New("minecraft transport not implemented")
+}

--- a/internal/transports/factory.go
+++ b/internal/transports/factory.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/nemored/pipo/internal/config"
 	"github.com/nemored/pipo/internal/core"
-	"github.com/nemored/pipo/internal/transports/noop"
+	"github.com/nemored/pipo/internal/store"
 )
 
-func Build(cfg config.ParsedConfig) ([]core.Transport, error) {
+func Build(cfg config.ParsedConfig, db *store.SQLiteStore) ([]core.Transport, error) {
 	knownBuses := make(map[string]struct{}, len(cfg.Buses))
 	for _, bus := range cfg.Buses {
 		knownBuses[bus.ID] = struct{}{}
@@ -29,7 +29,22 @@ func Build(cfg config.ParsedConfig) ([]core.Transport, error) {
 				return nil, fmt.Errorf("transport %d (%s) references unknown bus %q", idx, tc.Kind, busID)
 			}
 		}
-		out = append(out, noop.New(fmt.Sprintf("%s[%d]", tc.Kind, idx), busIDs))
+		switch tc.Kind {
+		case "Slack":
+			out = append(out, buildSlack(idx, tc, db))
+		case "Discord":
+			out = append(out, buildDiscord(idx, tc, db))
+		case "IRC":
+			out = append(out, buildIRC(idx, tc, db))
+		case "Mumble":
+			out = append(out, buildMumble(idx, tc, db))
+		case "Rachni":
+			out = append(out, buildRachni(idx, tc, db))
+		case "Minecraft":
+			out = append(out, notImplementedTransport{name: fmt.Sprintf("%s[%d]", tc.Kind, idx)})
+		default:
+			return nil, fmt.Errorf("transport %d has unsupported type %q", idx, tc.Kind)
+		}
 	}
 	return out, nil
 }

--- a/internal/transports/factory_test.go
+++ b/internal/transports/factory_test.go
@@ -1,0 +1,42 @@
+package transports
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nemored/pipo/internal/config"
+	"github.com/nemored/pipo/internal/store"
+)
+
+func TestBuildConstructsTypedAdapters(t *testing.T) {
+	cfg := config.ParsedConfig{
+		Buses: []config.Bus{{ID: "main"}},
+		Transports: []config.Transport{
+			{Kind: "Slack", ChannelMapping: map[string]string{"main": "C1"}},
+			{Kind: "Discord", ChannelMapping: map[string]string{"main": "1"}},
+			{Kind: "IRC", ChannelMapping: map[string]string{"main": "#chan"}},
+			{Kind: "Mumble", ChannelMapping: map[string]string{"main": "text"}, VoiceChannelMapping: map[string]string{"main": "voice"}},
+			{Kind: "Rachni", Buses: []string{"main"}},
+			{Kind: "Minecraft", Buses: []string{"main"}},
+		},
+	}
+	s, err := store.OpenSQLite(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer s.Close()
+
+	got, err := Build(cfg, s)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(got) != len(cfg.Transports) {
+		t.Fatalf("expected %d transports, got %d", len(cfg.Transports), len(got))
+	}
+	if got[0].Name() != "Slack[0]" || got[1].Name() != "Discord[1]" || got[2].Name() != "IRC[2]" {
+		t.Fatalf("unexpected adapter names: %q, %q, %q", got[0].Name(), got[1].Name(), got[2].Name())
+	}
+	if err := got[5].Run(context.Background(), nil); err == nil {
+		t.Fatalf("minecraft adapter should stay not implemented")
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide concrete Go transport entry points (Slack, Discord, IRC, Mumble, Rachni) and preserve runtime/connect/reconnect lifecycle semantics from the Rust implementation.
- Preserve channel mapping semantics and DB mapping behavior (shared `pipo_id` semantics and Rachni off-by-one behavior) while keeping Minecraft intentionally unimplemented.
- Create per-transport parity documentation to track completed vs pending compatibility items for incremental porting work.

### Description
- Change `transports.Build` signature to `Build(cfg, db *store.SQLiteStore)` and wire transport-specific builders for `Slack`, `Discord`, `IRC`, `Mumble`, `Rachni`, and an explicit Minecraft not-implemented transport in `internal/transports/factory.go`.
- Add `internal/transports/adapters.go` with a `transportAdapter` scaffold implementing connect/session/reconnect lifecycle (backoff, `connectFn`/`sessionFn`), channel mapping state (`channelToRemote`/`remoteToChannel`), and per-transport builder entry points.
- Thread the SQLite store into transport construction and add `InsertAllocatedIDRachni` in `internal/store/sqlite.go` to preserve the Rust Rachni insertion semantics (insert current id, increment counter, return post-increment value).
- Update `cmd/pipo/main.go` to pass the opened store into `transports.Build`, add unit tests for factory wiring (`internal/transports/factory_test.go`) and Rachni ID behavior (`internal/store/sqlite_test.go`), and add parity documents under `docs/parity/` for each transport.

### Testing
- Ran `go test ./...`, which executed package unit tests and completed successfully (all Go tests passed for `internal/config`, `internal/core`, `internal/store`, `internal/transports`, etc.).
- Ran `gofmt` on modified files to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ba2841108331bd1a69f504e7c0c2)