### PR TITLE
Add cross-language parity harness and high-risk fixtures for Slack↔Discord flows

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,6 +39,17 @@ go build -o pipo-go ./cmd/pipo
 CONFIG_PATH=path-to-config.json DB_PATH=path-to-db.sqlite3 ./pipo-go
 #+END_SRC
 
+*** Cross-language parity harness (high-risk fixtures)
+Use the fixture harness to run Go and Rust fixture runners against the same
+config/event corpus, then compare normalized outputs + DB side effects.
+
+#+BEGIN_SRC bash
+go run ./cmd/parity-harness -fixture docs/parity/fixtures/high-risk.json
+#+END_SRC
+
+This currently focuses on Slack↔Discord ID mapping, edits/deletes, thread
+fields, and reaction routing.
+
 ** Tasks
 *** TODO Improve translation of Slack formatting to Markdown formatting
 

--- a/cmd/parity-harness/main.go
+++ b/cmd/parity-harness/main.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+
+	"github.com/nemored/pipo/internal/config"
+	"github.com/nemored/pipo/internal/store"
+)
+
+type fixtureSet struct {
+	ConfigCases    []configCase    `json:"config_cases"`
+	OperationCases []operationCase `json:"operation_cases"`
+}
+
+type configCase struct {
+	Name string `json:"name"`
+	JSON string `json:"json"`
+}
+
+type operationCase struct {
+	Name  string `json:"name"`
+	Steps []step `json:"steps"`
+}
+
+type step struct {
+	Op              string  `json:"op"`
+	SlackID         *string `json:"slack_id,omitempty"`
+	DiscordID       *uint64 `json:"discord_id,omitempty"`
+	PipoID          *int64  `json:"pipo_id,omitempty"`
+	Emoji           *string `json:"emoji,omitempty"`
+	Remove          *bool   `json:"remove,omitempty"`
+	ThreadSlackTS   *string `json:"thread_slack_ts,omitempty"`
+	ThreadDiscordID *uint64 `json:"thread_discord_id,omitempty"`
+}
+
+type summary struct {
+	ConfigResults    []configResult    `json:"config_results"`
+	OperationResults []operationResult `json:"operation_results"`
+}
+
+type configResult struct {
+	Name   string `json:"name"`
+	OK     bool   `json:"ok"`
+	Detail string `json:"detail"`
+}
+
+type operationResult struct {
+	Name    string             `json:"name"`
+	Outputs []map[string]any   `json:"outputs"`
+	DBRows  []store.MessageRow `json:"db_rows"`
+}
+
+func main() {
+	fixturePath := flag.String("fixture", "docs/parity/fixtures/high-risk.json", "fixture set path")
+	flag.Parse()
+
+	fixture, err := readFixture(*fixturePath)
+	if err != nil {
+		fatal(err)
+	}
+
+	goSummary, err := runGoSummary(fixture)
+	if err != nil {
+		fatal(err)
+	}
+	rustSummary, err := runRustSummary(*fixturePath)
+	if err != nil {
+		fatal(err)
+	}
+
+	goNorm, err := json.Marshal(goSummary)
+	if err != nil {
+		fatal(err)
+	}
+	rustNorm, err := json.Marshal(rustSummary)
+	if err != nil {
+		fatal(err)
+	}
+
+	if !reflect.DeepEqual(json.RawMessage(goNorm), json.RawMessage(rustNorm)) {
+		fmt.Fprintln(os.Stderr, "divergence detected between Go and Rust outputs")
+		fmt.Println("=== GO ===")
+		fmt.Println(string(must(json.MarshalIndent(goSummary, "", "  ")).([]byte)))
+		fmt.Println("=== RUST ===")
+		fmt.Println(string(must(json.MarshalIndent(rustSummary, "", "  ")).([]byte)))
+		os.Exit(1)
+	}
+
+	fmt.Println("parity OK")
+	fmt.Println(string(must(json.MarshalIndent(goSummary, "", "  ")).([]byte)))
+}
+
+func runGoSummary(f fixtureSet) (summary, error) {
+	ctx := context.Background()
+	out := summary{}
+	for _, c := range f.ConfigCases {
+		var cfg struct {
+			Buses      []config.Bus       `json:"buses"`
+			Transports []config.Transport `json:"transports"`
+		}
+		err := decodeStrict([]byte(c.JSON), &cfg)
+		if err != nil {
+			out.ConfigResults = append(out.ConfigResults, configResult{Name: c.Name, OK: false, Detail: err.Error()})
+			continue
+		}
+		out.ConfigResults = append(out.ConfigResults, configResult{Name: c.Name, OK: true, Detail: fmt.Sprintf("parsed buses=%d transports=%d", len(cfg.Buses), len(cfg.Transports))})
+	}
+
+	for _, c := range f.OperationCases {
+		dbPath, err := tempDBPath()
+		if err != nil {
+			return summary{}, err
+		}
+		defer os.Remove(dbPath)
+		s, err := store.OpenSQLite(ctx, dbPath)
+		if err != nil {
+			return summary{}, err
+		}
+		outputs := make([]map[string]any, 0, len(c.Steps))
+		for _, st := range c.Steps {
+			switch st.Op {
+			case "insert_slack":
+				id, err := s.InsertOrReplaceSlack(ctx, mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "insert_slack", "pipo_id": id})
+			case "lookup_id_by_slack":
+				id, err := s.SelectIDBySlack(ctx, mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "lookup_id_by_slack", "pipo_id": id})
+			case "update_discord":
+				err := s.UpdateDiscordByID(ctx, mustI64(st.PipoID, "pipo_id"), mustU64(st.DiscordID, "discord_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "update_discord", "ok": true})
+			case "lookup_discord_by_slack":
+				id, err := s.SelectDiscordBySlack(ctx, mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "lookup_discord_by_slack", "discord_id": id})
+			case "insert_discord":
+				id, err := s.InsertOrReplaceDiscord(ctx, mustU64(st.DiscordID, "discord_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "insert_discord", "pipo_id": id})
+			case "lookup_id_by_discord":
+				id, err := s.SelectIDByDiscord(ctx, mustU64(st.DiscordID, "discord_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "lookup_id_by_discord", "pipo_id": id})
+			case "update_slack":
+				err := s.UpdateSlackByID(ctx, mustI64(st.PipoID, "pipo_id"), mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "update_slack", "ok": true})
+			case "route_edit_slack":
+				pipo, err := s.SelectIDBySlack(ctx, mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "route_edit_slack", "kind": "Text", "is_edit": true, "pipo_id": pipo, "thread": map[string]any{"slack_thread_ts": st.ThreadSlackTS}})
+			case "route_delete_discord":
+				pipo, err := s.SelectIDByDiscord(ctx, mustU64(st.DiscordID, "discord_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "route_delete_discord", "kind": "Delete", "pipo_id": pipo, "thread": map[string]any{"discord_thread": st.ThreadDiscordID}})
+			case "route_reaction_slack":
+				pipo, err := s.SelectIDBySlack(ctx, mustStr(st.SlackID, "slack_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "route_reaction_slack", "kind": "Reaction", "pipo_id": pipo, "emoji": mustStr(st.Emoji, "emoji"), "remove": mustBool(st.Remove), "thread": map[string]any{"slack_thread_ts": st.ThreadSlackTS}})
+			case "route_reaction_discord":
+				pipo, err := s.SelectIDByDiscord(ctx, mustU64(st.DiscordID, "discord_id"))
+				if err != nil {
+					return summary{}, err
+				}
+				outputs = append(outputs, map[string]any{"op": "route_reaction_discord", "kind": "Reaction", "pipo_id": pipo, "emoji": mustStr(st.Emoji, "emoji"), "remove": mustBool(st.Remove), "thread": map[string]any{"discord_thread": st.ThreadDiscordID}})
+			default:
+				return summary{}, fmt.Errorf("unsupported op: %s", st.Op)
+			}
+		}
+		rows, err := s.DebugRows(ctx)
+		if err != nil {
+			return summary{}, err
+		}
+		_ = s.Close()
+		out.OperationResults = append(out.OperationResults, operationResult{Name: c.Name, Outputs: outputs, DBRows: rows})
+	}
+	return out, nil
+}
+
+func runRustSummary(fixturePath string) (summary, error) {
+	cmd := exec.Command("cargo", "run", "--quiet", "--bin", "parity_fixture_runner", "--", fixturePath)
+	cmd.Dir = "."
+	cmd.Stderr = os.Stderr
+	blob, err := cmd.Output()
+	if err != nil {
+		return summary{}, fmt.Errorf("run rust fixture runner: %w", err)
+	}
+	var out summary
+	if err := json.Unmarshal(blob, &out); err != nil {
+		return summary{}, fmt.Errorf("decode rust summary: %w", err)
+	}
+	return out, nil
+}
+
+func readFixture(path string) (fixtureSet, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return fixtureSet{}, err
+	}
+	var out fixtureSet
+	if err := json.Unmarshal(blob, &out); err != nil {
+		return fixtureSet{}, err
+	}
+	return out, nil
+}
+
+func decodeStrict(data []byte, target any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(target); err != nil {
+		return err
+	}
+	if dec.More() {
+		return errors.New("unexpected trailing JSON content")
+	}
+	return nil
+}
+
+func tempDBPath() (string, error) {
+	f, err := os.CreateTemp("", "pipo-parity-*.db")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func must(v any, err error) any {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+func mustStr(v *string, n string) string {
+	if v == nil {
+		panic("missing " + n)
+	}
+	return *v
+}
+func mustI64(v *int64, n string) int64 {
+	if v == nil {
+		panic("missing " + n)
+	}
+	return *v
+}
+func mustU64(v *uint64, n string) uint64 {
+	if v == nil {
+		panic("missing " + n)
+	}
+	return *v
+}
+func mustBool(v *bool) bool {
+	if v == nil {
+		return false
+	}
+	return *v
+}
+func fatal(err error) { fmt.Fprintln(os.Stderr, err); os.Exit(2) }

--- a/docs/parity/fixtures/high-risk.json
+++ b/docs/parity/fixtures/high-risk.json
@@ -1,0 +1,30 @@
+{
+  "config_cases": [
+    {
+      "name": "valid-slack-discord",
+      "json": "{\n  \"buses\": [{\"id\":\"main\"}],\n  \"transports\": [\n    {\"transport\":\"Slack\",\"token\":\"x\",\"bot_token\":\"y\",\"channel_mapping\":{\"main\":\"C1\"}},\n    {\"transport\":\"Discord\",\"token\":\"z\",\"guild_id\":1,\"channel_mapping\":{\"main\":\"10\"}}\n  ]\n}"
+    },
+    {
+      "name": "unknown-field-discord",
+      "json": "{\n  \"buses\": [{\"id\":\"main\"}],\n  \"transports\": [\n    {\"transport\":\"Discord\",\"token\":\"z\",\"guild_id\":1,\"channel_mapping\":{\"main\":\"10\"},\"extra\":true}\n  ]\n}"
+    }
+  ],
+  "operation_cases": [
+    {
+      "name": "slack_discord_high_risk_routing",
+      "steps": [
+        {"op":"insert_slack","slack_id":"1700000000.100"},
+        {"op":"lookup_id_by_slack","slack_id":"1700000000.100"},
+        {"op":"update_discord","pipo_id":1,"discord_id":9911223344},
+        {"op":"lookup_discord_by_slack","slack_id":"1700000000.100"},
+        {"op":"route_edit_slack","slack_id":"1700000000.100","thread_slack_ts":"1700000000.100"},
+        {"op":"route_reaction_slack","slack_id":"1700000000.100","emoji":"thumbsup","remove":false,"thread_slack_ts":"1700000000.100"},
+        {"op":"insert_discord","discord_id":9911223345},
+        {"op":"lookup_id_by_discord","discord_id":9911223345},
+        {"op":"update_slack","pipo_id":2,"slack_id":"1700000001.500"},
+        {"op":"route_delete_discord","discord_id":9911223345,"thread_discord_id":445566},
+        {"op":"route_reaction_discord","discord_id":9911223345,"emoji":"rocket","remove":true,"thread_discord_id":445566}
+      ]
+    }
+  ]
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -20,6 +20,12 @@ type SQLiteStore struct {
 	nextID int64
 }
 
+type MessageRow struct {
+	ID        int64   `json:"id"`
+	SlackID   *string `json:"slack_id,omitempty"`
+	DiscordID *uint64 `json:"discord_id,omitempty"`
+}
+
 func OpenSQLite(ctx context.Context, path string) (*SQLiteStore, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -267,4 +273,39 @@ func (s *SQLiteStore) DebugCount(ctx context.Context) (int64, error) {
 		return 0, fmt.Errorf("count messages: %w", err)
 	}
 	return c, nil
+}
+
+func (s *SQLiteStore) DebugRows(ctx context.Context) ([]MessageRow, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, slackid, discordid FROM messages ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("query rows: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]MessageRow, 0)
+	for rows.Next() {
+		var (
+			id         int64
+			slackRaw   sql.NullString
+			discordRaw sql.NullInt64
+		)
+		if err := rows.Scan(&id, &slackRaw, &discordRaw); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		var slack *string
+		if slackRaw.Valid {
+			v := slackRaw.String
+			slack = &v
+		}
+		var discord *uint64
+		if discordRaw.Valid {
+			v := uint64(discordRaw.Int64)
+			discord = &v
+		}
+		out = append(out, MessageRow{ID: id, SlackID: slack, DiscordID: discord})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rows: %w", err)
+	}
+	return out, nil
 }

--- a/src/bin/parity_fixture_runner.rs
+++ b/src/bin/parity_fixture_runner.rs
@@ -1,0 +1,370 @@
+use anyhow::{anyhow, Context};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{env, fs};
+
+#[derive(Debug, Deserialize)]
+struct FixtureSet {
+    config_cases: Vec<ConfigCase>,
+    operation_cases: Vec<OperationCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigCase {
+    name: String,
+    json: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OperationCase {
+    name: String,
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Step {
+    op: String,
+    slack_id: Option<String>,
+    discord_id: Option<u64>,
+    pipo_id: Option<i64>,
+    emoji: Option<String>,
+    remove: Option<bool>,
+    thread_slack_ts: Option<String>,
+    thread_discord_id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParsedConfig {
+    buses: Vec<ConfigBus>,
+    transports: Vec<ConfigTransport>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigBus {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "transport")]
+enum ConfigTransport {
+    IRC {
+        nickname: String,
+        server: String,
+        use_tls: bool,
+        img_root: String,
+        channel_mapping: std::collections::HashMap<String, String>,
+    },
+    Discord {
+        token: String,
+        guild_id: u64,
+        channel_mapping: std::collections::HashMap<String, String>,
+    },
+    Slack {
+        token: String,
+        bot_token: String,
+        channel_mapping: std::collections::HashMap<String, String>,
+    },
+    Minecraft {
+        username: String,
+        buses: Vec<String>,
+    },
+    Mumble {
+        server: String,
+        password: Option<String>,
+        nickname: String,
+        client_cert: Option<String>,
+        server_cert: Option<String>,
+        comment: Option<String>,
+        channel_mapping: std::collections::HashMap<String, String>,
+        voice_channel_mapping: std::collections::HashMap<String, String>,
+    },
+    Rachni {
+        server: String,
+        api_key: String,
+        interval: u64,
+        buses: Vec<String>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct HarnessSummary {
+    config_results: Vec<ConfigResult>,
+    operation_results: Vec<OperationResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigResult {
+    name: String,
+    ok: bool,
+    detail: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OperationResult {
+    name: String,
+    outputs: Vec<Value>,
+    db_rows: Vec<DBRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct DBRow {
+    id: i64,
+    slack_id: Option<String>,
+    discord_id: Option<u64>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let fixture_path = env::args()
+        .nth(1)
+        .ok_or_else(|| anyhow!("usage: parity_fixture_runner <fixture.json>"))?;
+    let raw = fs::read_to_string(&fixture_path).context("read fixture file")?;
+    let fixture: FixtureSet = serde_json::from_str(&raw).context("parse fixture JSON")?;
+
+    let mut config_results = Vec::new();
+    for c in fixture.config_cases {
+        let parsed = serde_json::from_str::<ParsedConfig>(&c.json);
+        match parsed {
+            Ok(cfg) => config_results.push(ConfigResult {
+                name: c.name,
+                ok: true,
+                detail: format!(
+                    "parsed buses={} transports={}",
+                    cfg.buses.len(),
+                    cfg.transports.len()
+                ),
+            }),
+            Err(err) => config_results.push(ConfigResult {
+                name: c.name,
+                ok: false,
+                detail: err.to_string(),
+            }),
+        }
+    }
+
+    let mut operation_results = Vec::new();
+    for c in fixture.operation_cases {
+        let conn = Connection::open_in_memory().context("open sqlite in memory")?;
+        bootstrap(&conn)?;
+        let mut next_id: i64 = 1;
+        let mut outputs: Vec<Value> = Vec::new();
+
+        for step in c.steps {
+            match step.op.as_str() {
+                "insert_slack" => {
+                    let id = alloc_and_insert_slack(
+                        &conn,
+                        &mut next_id,
+                        need_str(&step.slack_id, "slack_id")?,
+                    )?;
+                    outputs.push(serde_json::json!({"op":"insert_slack","pipo_id":id}));
+                }
+                "lookup_id_by_slack" => {
+                    let id = select_id_by_slack(&conn, need_str(&step.slack_id, "slack_id")?)?;
+                    outputs.push(serde_json::json!({"op":"lookup_id_by_slack","pipo_id":id}));
+                }
+                "update_discord" => {
+                    conn.execute(
+                        "UPDATE messages SET discordid = ?2 WHERE id = ?1",
+                        params![
+                            need_i64(step.pipo_id, "pipo_id")?,
+                            need_u64(step.discord_id, "discord_id")?
+                        ],
+                    )?;
+                    outputs.push(serde_json::json!({"op":"update_discord","ok":true}));
+                }
+                "lookup_discord_by_slack" => {
+                    let discord =
+                        select_discord_by_slack(&conn, need_str(&step.slack_id, "slack_id")?)?;
+                    outputs.push(
+                        serde_json::json!({"op":"lookup_discord_by_slack","discord_id":discord}),
+                    );
+                }
+                "insert_discord" => {
+                    let id = alloc_and_insert_discord(
+                        &conn,
+                        &mut next_id,
+                        need_u64(step.discord_id, "discord_id")?,
+                    )?;
+                    outputs.push(serde_json::json!({"op":"insert_discord","pipo_id":id}));
+                }
+                "lookup_id_by_discord" => {
+                    let id = select_id_by_discord(&conn, need_u64(step.discord_id, "discord_id")?)?;
+                    outputs.push(serde_json::json!({"op":"lookup_id_by_discord","pipo_id":id}));
+                }
+                "update_slack" => {
+                    conn.execute(
+                        "UPDATE messages SET slackid = ?2 WHERE id = ?1",
+                        params![
+                            need_i64(step.pipo_id, "pipo_id")?,
+                            need_str(&step.slack_id, "slack_id")?
+                        ],
+                    )?;
+                    outputs.push(serde_json::json!({"op":"update_slack","ok":true}));
+                }
+                "route_edit_slack" => {
+                    let pipo = select_id_by_slack(&conn, need_str(&step.slack_id, "slack_id")?)?;
+                    outputs.push(serde_json::json!({
+                        "op":"route_edit_slack",
+                        "kind":"Text",
+                        "is_edit":true,
+                        "pipo_id":pipo,
+                        "thread":{"slack_thread_ts":step.thread_slack_ts}
+                    }));
+                }
+                "route_delete_discord" => {
+                    let pipo =
+                        select_id_by_discord(&conn, need_u64(step.discord_id, "discord_id")?)?;
+                    outputs.push(serde_json::json!({
+                        "op":"route_delete_discord",
+                        "kind":"Delete",
+                        "pipo_id":pipo,
+                        "thread":{"discord_thread":step.thread_discord_id}
+                    }));
+                }
+                "route_reaction_slack" => {
+                    let pipo = select_id_by_slack(&conn, need_str(&step.slack_id, "slack_id")?)?;
+                    outputs.push(serde_json::json!({
+                        "op":"route_reaction_slack",
+                        "kind":"Reaction",
+                        "pipo_id":pipo,
+                        "emoji":need_str(&step.emoji, "emoji")?,
+                        "remove":step.remove.unwrap_or(false),
+                        "thread":{"slack_thread_ts":step.thread_slack_ts}
+                    }));
+                }
+                "route_reaction_discord" => {
+                    let pipo =
+                        select_id_by_discord(&conn, need_u64(step.discord_id, "discord_id")?)?;
+                    outputs.push(serde_json::json!({
+                        "op":"route_reaction_discord",
+                        "kind":"Reaction",
+                        "pipo_id":pipo,
+                        "emoji":need_str(&step.emoji, "emoji")?,
+                        "remove":step.remove.unwrap_or(false),
+                        "thread":{"discord_thread":step.thread_discord_id}
+                    }));
+                }
+                _ => return Err(anyhow!("unsupported op: {}", step.op)),
+            }
+        }
+
+        operation_results.push(OperationResult {
+            name: c.name,
+            outputs,
+            db_rows: dump_rows(&conn)?,
+        });
+    }
+
+    let summary = HarnessSummary {
+        config_results,
+        operation_results,
+    };
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    Ok(())
+}
+
+fn bootstrap(conn: &Connection) -> anyhow::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE messages (
+            id INTEGER PRIMARY KEY,
+            slackid TEXT,
+            discordid INTEGER,
+            modtime DEFAULT (strftime('%Y-%m-%d %H:%M:%S:%s', 'now', 'localtime'))
+        );",
+    )?;
+    Ok(())
+}
+
+fn alloc(next_id: &mut i64) -> i64 {
+    let id = *next_id;
+    *next_id += 1;
+    if *next_id > 40000 {
+        *next_id = 0;
+    }
+    id
+}
+
+fn alloc_and_insert_slack(
+    conn: &Connection,
+    next_id: &mut i64,
+    slack_id: &str,
+) -> anyhow::Result<i64> {
+    let id = alloc(next_id);
+    conn.execute(
+        "INSERT OR REPLACE INTO messages (id, slackid) VALUES (?1, ?2)",
+        params![id, slack_id],
+    )?;
+    Ok(id)
+}
+
+fn alloc_and_insert_discord(
+    conn: &Connection,
+    next_id: &mut i64,
+    discord_id: u64,
+) -> anyhow::Result<i64> {
+    let id = alloc(next_id);
+    conn.execute(
+        "INSERT OR REPLACE INTO messages (id, discordid) VALUES (?1, ?2)",
+        params![id, discord_id],
+    )?;
+    Ok(id)
+}
+
+fn select_id_by_slack(conn: &Connection, slack_id: &str) -> anyhow::Result<Option<i64>> {
+    Ok(conn
+        .query_row(
+            "SELECT id FROM messages WHERE slackid = ?1",
+            params![slack_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?)
+}
+
+fn select_id_by_discord(conn: &Connection, discord_id: u64) -> anyhow::Result<Option<i64>> {
+    Ok(conn
+        .query_row(
+            "SELECT id FROM messages WHERE discordid = ?1",
+            params![discord_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?)
+}
+
+fn select_discord_by_slack(conn: &Connection, slack_id: &str) -> anyhow::Result<Option<u64>> {
+    Ok(conn
+        .query_row(
+            "SELECT discordid FROM messages WHERE slackid = ?1",
+            params![slack_id],
+            |r| r.get::<_, u64>(0),
+        )
+        .optional()?)
+}
+
+fn dump_rows(conn: &Connection) -> anyhow::Result<Vec<DBRow>> {
+    let mut stmt = conn.prepare("SELECT id, slackid, discordid FROM messages ORDER BY id")?;
+    let rows = stmt.query_map([], |r| {
+        Ok(DBRow {
+            id: r.get(0)?,
+            slack_id: r.get(1)?,
+            discord_id: r.get(2)?,
+        })
+    })?;
+    let mut out = vec![];
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+fn need_str<'a>(v: &'a Option<String>, name: &str) -> anyhow::Result<&'a str> {
+    v.as_deref().ok_or_else(|| anyhow!("missing {}", name))
+}
+
+fn need_u64(v: Option<u64>, name: &str) -> anyhow::Result<u64> {
+    v.ok_or_else(|| anyhow!("missing {}", name))
+}
+
+fn need_i64(v: Option<i64>, name: &str) -> anyhow::Result<i64> {
+    v.ok_or_else(|| anyhow!("missing {}", name))
+}


### PR DESCRIPTION
### Motivation
- Add a deterministic harness to catch cross-implementation divergences before merge by exercising identical fixture inputs against both Rust and Go codepaths. 
- Focus on high-risk paths where subtle differences cause production misrouting: Slack↔Discord ID mapping, edits/deletes, thread fields, and reaction routing. 
- Surface DB side-effects as part of parity checks so mapping round-trips can be compared row-for-row between implementations.

### Description
- Add a Go parity harness CLI at `cmd/parity-harness/main.go` that loads fixture sets, runs the Go-side operations, invokes the Rust runner, normalizes outputs, and fails when summaries differ. 
- Add a Rust fixture runner binary at `src/bin/parity_fixture_runner.rs` that executes the same config and operation fixtures and emits a normalized JSON summary for comparison. 
- Add a high-risk fixture corpus at `docs/parity/fixtures/high-risk.json` that encodes config parsing cases and an operation sequence targeting Slack↔Discord mapping, edits/deletes, thread propagation, and reaction routing. 
- Extend the Go SQLite store with `MessageRow` and a `DebugRows` method in `internal/store/sqlite.go` to export deterministic DB rows for comparison, and document harness usage in `README.org`.

### Testing
- Ran `go test ./internal/... ./cmd/parity-harness` which completed successfully and the Go-side unit/integration checks passed. 
- Executed the Go parity harness locally during development and fixed an initial NULL/ID alignment issue in fixtures; the harness is designed to invoke the Rust runner for full parity checks. 
- Attempted `cargo check --bin parity_fixture_runner` / `cargo run` to validate the Rust runner build, but the Rust dependency compilation timed out / was blocked in this environment and could not complete within the session. 
- Result: Go-side tests pass; full cross-language parity verification requires a successful Rust build (expected to run in CI or a dev environment with the Rust toolchain available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7bf93c19883319fe3e1ee8dce9647)