### PR TITLE
Add staged Go rollout plan with telemetry, structured logs, health endpoint, and DB error instrumentation

### DIFF
--- a/cmd/pipo/main.go
+++ b/cmd/pipo/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -10,6 +13,7 @@ import (
 	"github.com/nemored/pipo/internal/config"
 	"github.com/nemored/pipo/internal/core"
 	"github.com/nemored/pipo/internal/store"
+	"github.com/nemored/pipo/internal/telemetry"
 	"github.com/nemored/pipo/internal/transports"
 )
 
@@ -21,6 +25,10 @@ func main() {
 }
 
 func run(args []string, getenv func(string) string) error {
+	logger := telemetry.NewJSONLogger()
+	metrics := &telemetry.Metrics{}
+	store.SetErrorObserver(dbObserver{log: logger, metrics: metrics})
+
 	if len(args) > 1 && args[1] == "migrate-db" {
 		dbPath := ""
 		if len(args) > 2 {
@@ -59,7 +67,7 @@ func run(args []string, getenv func(string) string) error {
 		return err
 	}
 
-	transportRunners, err := transports.Build(cfg, s)
+	transportRunners, err := transports.Build(cfg, s, logger, metrics)
 	if err != nil {
 		return err
 	}
@@ -69,11 +77,54 @@ func run(args []string, getenv func(string) string) error {
 		busIDs = append(busIDs, bus.ID)
 	}
 
-	runtime := core.NewRuntime(busIDs, transportRunners)
+	runtime := core.NewRuntime(busIDs, transportRunners, logger, metrics)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdownHealth, err := serveHealthEndpoint(getenv("HEALTH_ADDR"), logger, metrics)
+	if err != nil {
+		return err
+	}
+	defer shutdownHealth(context.Background())
+
 	return runtime.Run(ctx)
+}
+
+type dbObserver struct {
+	log     *slog.Logger
+	metrics *telemetry.Metrics
+}
+
+func (o dbObserver) ObserveDBError(operation string, err error) {
+	if o.metrics != nil {
+		o.metrics.IncDBError()
+	}
+	if o.log != nil {
+		o.log.Error("db operation failed", "operation", operation, "error", err)
+	}
+}
+
+func serveHealthEndpoint(addr string, logger *slog.Logger, metrics *telemetry.Metrics) (func(context.Context) error, error) {
+	if addr == "" {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "metrics": metrics.Snapshot()})
+	})
+
+	srv := &http.Server{Addr: addr, Handler: mux}
+	go func() {
+		if logger != nil {
+			logger.Info("health endpoint started", "addr", addr)
+		}
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed && logger != nil {
+			logger.Error("health endpoint stopped", "error", err)
+		}
+	}()
+	return srv.Shutdown, nil
 }
 
 func binaryName(args []string) string {

--- a/docs/go-rollout-deployment-plan.md
+++ b/docs/go-rollout-deployment-plan.md
@@ -1,0 +1,59 @@
+# Go rewrite deployment and rollback plan
+
+## Deployment stages
+
+### Stage 1: shadow / limited environment
+- Deploy the Go binary to a shadow environment that reads production-equivalent traffic but does not become the primary forwarder.
+- Keep the Rust binary as the active forwarding path.
+- Enable health endpoint (`HEALTH_ADDR`) and collect structured logs for:
+  - connect attempts/success/failure per transport,
+  - queue-pressure drops,
+  - forwarding/session failures,
+  - DB operation errors.
+- Gate progression on sustained healthy telemetry (no elevated DB errors, stable connect success ratio, acceptable queue pressure rate).
+
+### Stage 2: partial production channels
+- Shift a bounded subset of production channels/buses to the Go binary.
+- Keep the Rust binary warm and runnable with the same config and DB path.
+- Validate parity in message forwarding and ID mapping for selected channels.
+- Monitor the same health metrics with SLO thresholds stricter than Stage 1.
+- Increase the channel set gradually if metrics stay green and no regressions are observed.
+
+### Stage 3: full replacement
+- Promote the Go binary to all production channels.
+- Keep Rust binary and deployment manifests available for immediate rollback.
+- Continue monitoring health endpoint and structured logs during the first full-release window.
+- Declare rollout complete only after a full business cycle with no critical forwarding or DB incidents.
+
+## Observability contract
+
+- Structured logs are emitted in JSON for transport lifecycle, queue pressure, forwarding failures, and DB errors.
+- Health metrics are exposed via `/healthz` when `HEALTH_ADDR` is configured.
+- `/healthz` returns `status=ok` and counters:
+  - `connect_attempts`
+  - `connect_successes`
+  - `connect_failures`
+  - `queue_pressure_drops`
+  - `forwarding_failures`
+  - `db_errors`
+
+## Rollback procedure (Go -> Rust)
+
+1. **Stop Go traffic ownership**
+   - Remove Go from active forwarding (or scale to zero) and restore Rust as active.
+2. **Reuse existing DB file**
+   - Point Rust to the same SQLite DB path used by Go.
+3. **Reuse existing config**
+   - Use the same config JSON (or equivalent channel mappings) previously validated in staging.
+4. **Do not run destructive migrations**
+   - The Go migration path is idempotent and non-destructive (`CREATE TABLE IF NOT EXISTS`, `CREATE TRIGGER IF NOT EXISTS`).
+   - Rollback does not depend on schema rewrites or data deletion.
+5. **Verify continuity**
+   - Confirm Rust starts cleanly and can read/write existing message ID mappings.
+   - Confirm forwarding resumes with expected channel routes.
+
+## Continuity guarantees
+
+- **DB continuity:** Go uses Rust-compatible `messages` table semantics; rollback reuses the same DB file.
+- **Config continuity:** CLI/env config path handling remains compatible (`CONFIG_PATH` / positional config arg and `DB_PATH` / positional DB arg).
+- **No destructive dependency:** No stage or rollback step requires destructive migration.

--- a/internal/core/bus.go
+++ b/internal/core/bus.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/nemored/pipo/internal/model"
+	"github.com/nemored/pipo/internal/telemetry"
 )
 
 var ErrUnknownBus = errors.New("unknown bus")
@@ -14,6 +16,8 @@ var ErrUnknownBus = errors.New("unknown bus")
 type Broker struct {
 	mu    sync.RWMutex
 	buses map[string]*bus
+	log   *slog.Logger
+	m     *telemetry.Metrics
 }
 
 type bus struct {
@@ -21,12 +25,12 @@ type bus struct {
 	subscribers map[chan model.Event]struct{}
 }
 
-func NewBroker(busIDs []string) *Broker {
+func NewBroker(busIDs []string, logger *slog.Logger, m *telemetry.Metrics) *Broker {
 	buses := make(map[string]*bus, len(busIDs))
 	for _, id := range busIDs {
 		buses[id] = &bus{id: id, subscribers: map[chan model.Event]struct{}{}}
 	}
-	return &Broker{buses: buses}
+	return &Broker{buses: buses, log: logger, m: m}
 }
 
 func (b *Broker) Publish(busID string, event model.Event) error {
@@ -41,6 +45,12 @@ func (b *Broker) Publish(busID string, event model.Event) error {
 		case ch <- event:
 		default:
 			// Drop when subscriber is saturated to avoid global stalls.
+			if b.m != nil {
+				b.m.IncQueuePressure()
+			}
+			if b.log != nil {
+				b.log.Warn("queue pressure drop", "bus_id", busID, "queue_len", len(ch), "queue_cap", cap(ch), "event_kind", event.Kind)
+			}
 		}
 	}
 	b.mu.RUnlock()

--- a/internal/core/bus_test.go
+++ b/internal/core/bus_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBrokerPublishesToBusSubscribers(t *testing.T) {
-	b := NewBroker([]string{"alpha", "beta"})
+	b := NewBroker([]string{"alpha", "beta"}, nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/core/runtime.go
+++ b/internal/core/runtime.go
@@ -3,9 +3,11 @@ package core
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/nemored/pipo/internal/model"
+	"github.com/nemored/pipo/internal/telemetry"
 )
 
 type RuntimeAPI interface {
@@ -21,10 +23,11 @@ type Transport interface {
 type Runtime struct {
 	broker     *Broker
 	transports []Transport
+	log        *slog.Logger
 }
 
-func NewRuntime(busIDs []string, transports []Transport) *Runtime {
-	return &Runtime{broker: NewBroker(busIDs), transports: transports}
+func NewRuntime(busIDs []string, transports []Transport, logger *slog.Logger, m *telemetry.Metrics) *Runtime {
+	return &Runtime{broker: NewBroker(busIDs, logger, m), transports: transports, log: logger}
 }
 
 func (r *Runtime) Publish(busID string, event model.Event) error {
@@ -47,9 +50,19 @@ func (r *Runtime) Run(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			if r.log != nil {
+				r.log.Info("transport starting", "transport", transport.Name())
+			}
 			if err := transport.Run(ctx, r); err != nil {
+				if r.log != nil {
+					r.log.Error("transport exited with error", "transport", transport.Name(), "error", err)
+				}
 				errCh <- fmt.Errorf("transport %s: %w", transport.Name(), err)
 				cancel()
+				return
+			}
+			if r.log != nil {
+				r.log.Info("transport stopped", "transport", transport.Name())
 			}
 		}()
 	}

--- a/internal/store/observe.go
+++ b/internal/store/observe.go
@@ -1,0 +1,24 @@
+package store
+
+import "sync/atomic"
+
+type ErrorObserver interface {
+	ObserveDBError(operation string, err error)
+}
+
+var dbErrorObserver atomic.Value
+
+func SetErrorObserver(o ErrorObserver) {
+	dbErrorObserver.Store(o)
+}
+
+func observeDBError(operation string, err error) {
+	if err == nil {
+		return
+	}
+	v := dbErrorObserver.Load()
+	if v == nil {
+		return
+	}
+	v.(ErrorObserver).ObserveDBError(operation, err)
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -29,20 +29,24 @@ type MessageRow struct {
 func OpenSQLite(ctx context.Context, path string) (*SQLiteStore, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
+		observeDBError("open", err)
 		return nil, err
 	}
 	if err := db.PingContext(ctx); err != nil {
+		observeDBError("ping", err)
 		_ = db.Close()
 		return nil, err
 	}
 
 	if err := bootstrapMessagesSchema(ctx, db); err != nil {
+		observeDBError("bootstrap_schema", err)
 		_ = db.Close()
 		return nil, err
 	}
 
 	nextID, err := seedNextID(ctx, db)
 	if err != nil {
+		observeDBError("seed_next_id", err)
 		_ = db.Close()
 		return nil, err
 	}
@@ -59,6 +63,7 @@ func bootstrapMessagesSchema(ctx context.Context, db *sql.DB) error {
 	var name string
 	err := db.QueryRowContext(ctx, tableExists).Scan(&name)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		observeDBError("schema_table_exists", err)
 		return err
 	}
 	if err == nil {
@@ -79,6 +84,7 @@ func bootstrapMessagesSchema(ctx context.Context, db *sql.DB) error {
 		 where id = old.id;
 	end;`
 	_, err = db.ExecContext(ctx, schema)
+	observeDBError("schema_exec", err)
 	return err
 }
 
@@ -89,6 +95,7 @@ func seedNextID(ctx context.Context, db *sql.DB) (int64, error) {
 	if errors.Is(err, sql.ErrNoRows) {
 		id = 0
 	} else if err != nil {
+		observeDBError("seed_query", err)
 		return 0, err
 	}
 	return id + 1, nil
@@ -110,6 +117,7 @@ func (s *SQLiteStore) InsertAllocatedID(ctx context.Context) (int64, error) {
 	id := s.allocID()
 	const q = `INSERT OR REPLACE INTO messages (id) VALUES (?1)`
 	if _, err := s.db.ExecContext(ctx, q, id); err != nil {
+		observeDBError("insert_allocated_id", err)
 		return 0, err
 	}
 	return id, nil
@@ -129,6 +137,7 @@ func (s *SQLiteStore) InsertAllocatedIDRachni(ctx context.Context) (int64, error
 
 	const q = `INSERT OR REPLACE INTO messages (id) VALUES (?1)`
 	if _, err := s.db.ExecContext(ctx, q, id); err != nil {
+		observeDBError("insert_allocated_id_rachni", err)
 		return 0, err
 	}
 	return ret, nil
@@ -138,6 +147,7 @@ func (s *SQLiteStore) InsertOrReplaceSlack(ctx context.Context, slackID string) 
 	id := s.allocID()
 	const q = `INSERT OR REPLACE INTO messages (id, slackid) VALUES (?1, ?2)`
 	if _, err := s.db.ExecContext(ctx, q, id, slackID); err != nil {
+		observeDBError("insert_or_replace_slack", err)
 		return 0, err
 	}
 	return id, nil
@@ -146,6 +156,7 @@ func (s *SQLiteStore) InsertOrReplaceSlack(ctx context.Context, slackID string) 
 func (s *SQLiteStore) UpdateSlackByID(ctx context.Context, pipoID int64, slackID string) error {
 	const q = `UPDATE messages SET slackid = ?2 WHERE id = ?1`
 	_, err := s.db.ExecContext(ctx, q, pipoID, slackID)
+	observeDBError("update_slack_by_id", err)
 	return err
 }
 
@@ -157,6 +168,7 @@ func (s *SQLiteStore) SelectIDBySlack(ctx context.Context, slackID string) (*int
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_id_by_slack", err)
 		return nil, err
 	}
 	return &id, nil
@@ -170,6 +182,7 @@ func (s *SQLiteStore) SelectSlackByID(ctx context.Context, pipoID int64) (*strin
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_slack_by_id", err)
 		return nil, err
 	}
 	return &id, nil
@@ -183,6 +196,7 @@ func (s *SQLiteStore) SelectSlackByDiscord(ctx context.Context, discordID uint64
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_slack_by_discord", err)
 		return nil, err
 	}
 	return &id, nil
@@ -196,6 +210,7 @@ func (s *SQLiteStore) SelectDiscordBySlack(ctx context.Context, slackID string) 
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_discord_by_slack", err)
 		return nil, err
 	}
 	return &id, nil
@@ -205,6 +220,7 @@ func (s *SQLiteStore) InsertOrReplaceDiscord(ctx context.Context, discordID uint
 	id := s.allocID()
 	const q = `INSERT OR REPLACE INTO messages (id, discordid) VALUES (?1, ?2)`
 	if _, err := s.db.ExecContext(ctx, q, id, discordID); err != nil {
+		observeDBError("insert_or_replace_discord", err)
 		return 0, err
 	}
 	return id, nil
@@ -213,6 +229,7 @@ func (s *SQLiteStore) InsertOrReplaceDiscord(ctx context.Context, discordID uint
 func (s *SQLiteStore) UpdateDiscordByID(ctx context.Context, pipoID int64, discordID uint64) error {
 	const q = `UPDATE messages SET discordid = ?2 WHERE id = ?1`
 	_, err := s.db.ExecContext(ctx, q, pipoID, discordID)
+	observeDBError("update_discord_by_id", err)
 	return err
 }
 
@@ -224,6 +241,7 @@ func (s *SQLiteStore) SelectIDByDiscord(ctx context.Context, discordID uint64) (
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_id_by_discord", err)
 		return nil, err
 	}
 	return &id, nil
@@ -237,6 +255,7 @@ func (s *SQLiteStore) SelectDiscordByID(ctx context.Context, pipoID int64) (*uin
 		return nil, nil
 	}
 	if err != nil {
+		observeDBError("select_discord_by_id", err)
 		return nil, err
 	}
 	return &id, nil
@@ -252,6 +271,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		modtime   DEFAULT (strftime('%Y-%m-%d %H:%M:%S:%s', 'now', 'localtime'))
 	)`
 	if _, err := s.db.ExecContext(ctx, createTable); err != nil {
+		observeDBError("migrate_create_table", err)
 		return err
 	}
 	const createTrigger = `CREATE TRIGGER IF NOT EXISTS updatemodtime
@@ -262,6 +282,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 		 where id = old.id;
 	end;`
 	if _, err := s.db.ExecContext(ctx, createTrigger); err != nil {
+		observeDBError("migrate_create_trigger", err)
 		return err
 	}
 	return nil
@@ -270,6 +291,7 @@ func (s *SQLiteStore) Migrate(ctx context.Context) error {
 func (s *SQLiteStore) DebugCount(ctx context.Context) (int64, error) {
 	var c int64
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM messages`).Scan(&c); err != nil {
+		observeDBError("debug_count", err)
 		return 0, fmt.Errorf("count messages: %w", err)
 	}
 	return c, nil
@@ -278,6 +300,7 @@ func (s *SQLiteStore) DebugCount(ctx context.Context) (int64, error) {
 func (s *SQLiteStore) DebugRows(ctx context.Context) ([]MessageRow, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, slackid, discordid FROM messages ORDER BY id`)
 	if err != nil {
+		observeDBError("debug_rows_query", err)
 		return nil, fmt.Errorf("query rows: %w", err)
 	}
 	defer rows.Close()
@@ -290,6 +313,7 @@ func (s *SQLiteStore) DebugRows(ctx context.Context) ([]MessageRow, error) {
 			discordRaw sql.NullInt64
 		)
 		if err := rows.Scan(&id, &slackRaw, &discordRaw); err != nil {
+			observeDBError("debug_rows_scan", err)
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 		var slack *string
@@ -305,6 +329,7 @@ func (s *SQLiteStore) DebugRows(ctx context.Context) ([]MessageRow, error) {
 		out = append(out, MessageRow{ID: id, SlackID: slack, DiscordID: discord})
 	}
 	if err := rows.Err(); err != nil {
+		observeDBError("debug_rows_iterate", err)
 		return nil, fmt.Errorf("iterate rows: %w", err)
 	}
 	return out, nil

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,54 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync/atomic"
+)
+
+type Metrics struct {
+	connectAttempts    atomic.Int64
+	connectSuccesses   atomic.Int64
+	connectFailures    atomic.Int64
+	queuePressureDrops atomic.Int64
+	forwardingFailures atomic.Int64
+	dbErrors           atomic.Int64
+}
+
+type Snapshot struct {
+	ConnectAttempts    int64 `json:"connect_attempts"`
+	ConnectSuccesses   int64 `json:"connect_successes"`
+	ConnectFailures    int64 `json:"connect_failures"`
+	QueuePressureDrops int64 `json:"queue_pressure_drops"`
+	ForwardingFailures int64 `json:"forwarding_failures"`
+	DBErrors           int64 `json:"db_errors"`
+}
+
+func NewJSONLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+func (m *Metrics) IncConnectAttempt() { m.connectAttempts.Add(1) }
+func (m *Metrics) IncConnectSuccess() { m.connectSuccesses.Add(1) }
+func (m *Metrics) IncConnectFailure() { m.connectFailures.Add(1) }
+func (m *Metrics) IncQueuePressure()  { m.queuePressureDrops.Add(1) }
+func (m *Metrics) IncForwardingFail() { m.forwardingFailures.Add(1) }
+func (m *Metrics) IncDBError()        { m.dbErrors.Add(1) }
+func (m *Metrics) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Snapshot())
+}
+
+func (m *Metrics) Snapshot() Snapshot {
+	if m == nil {
+		return Snapshot{}
+	}
+	return Snapshot{
+		ConnectAttempts:    m.connectAttempts.Load(),
+		ConnectSuccesses:   m.connectSuccesses.Load(),
+		ConnectFailures:    m.connectFailures.Load(),
+		QueuePressureDrops: m.queuePressureDrops.Load(),
+		ForwardingFailures: m.forwardingFailures.Load(),
+		DBErrors:           m.dbErrors.Load(),
+	}
+}

--- a/internal/transports/adapters.go
+++ b/internal/transports/adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/nemored/pipo/internal/core"
 	"github.com/nemored/pipo/internal/model"
 	"github.com/nemored/pipo/internal/store"
+	"github.com/nemored/pipo/internal/telemetry"
 )
 
 var errReconnect = errors.New("reconnect requested")
@@ -23,6 +25,8 @@ type transportAdapter struct {
 	remoteToChannel map[string]string
 	buses           []string
 	store           *store.SQLiteStore
+	log             *slog.Logger
+	metrics         *telemetry.Metrics
 	connectFn       func(context.Context) error
 	sessionFn       func(context.Context, core.RuntimeAPI) error
 }
@@ -32,7 +36,19 @@ func (t *transportAdapter) Name() string { return t.name }
 func (t *transportAdapter) Run(ctx context.Context, api core.RuntimeAPI) error {
 	backoff := time.Second
 	for {
+		if t.metrics != nil {
+			t.metrics.IncConnectAttempt()
+		}
+		if t.log != nil {
+			t.log.Info("transport connect attempt", "transport", t.name)
+		}
 		if err := t.connectFn(ctx); err != nil {
+			if t.metrics != nil {
+				t.metrics.IncConnectFailure()
+			}
+			if t.log != nil {
+				t.log.Warn("transport connect failed", "transport", t.name, "error", err, "backoff", backoff.String())
+			}
 			if ctx.Err() != nil {
 				return nil
 			}
@@ -41,6 +57,12 @@ func (t *transportAdapter) Run(ctx context.Context, api core.RuntimeAPI) error {
 			}
 			backoff = minDuration(backoff*2, 30*time.Second)
 			continue
+		}
+		if t.metrics != nil {
+			t.metrics.IncConnectSuccess()
+		}
+		if t.log != nil {
+			t.log.Info("transport connected", "transport", t.name)
 		}
 		backoff = time.Second
 		err := t.sessionFn(ctx, api)
@@ -51,10 +73,19 @@ func (t *transportAdapter) Run(ctx context.Context, api core.RuntimeAPI) error {
 			return nil
 		}
 		if errors.Is(err, errReconnect) {
+			if t.log != nil {
+				t.log.Warn("transport requested reconnect", "transport", t.name)
+			}
 			if !sleepWithContext(ctx, time.Second) {
 				return nil
 			}
 			continue
+		}
+		if t.metrics != nil {
+			t.metrics.IncForwardingFail()
+		}
+		if t.log != nil {
+			t.log.Error("transport session failed", "transport", t.name, "error", err)
 		}
 		return err
 	}
@@ -78,7 +109,7 @@ func sleepWithContext(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-func baseAdapter(kind string, idx int, tc config.Transport, s *store.SQLiteStore) *transportAdapter {
+func baseAdapter(kind string, idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) *transportAdapter {
 	remoteToChannel := make(map[string]string, len(tc.ChannelMapping))
 	buses := make([]string, 0, len(tc.ChannelMapping))
 	for busID, remoteID := range tc.ChannelMapping {
@@ -92,8 +123,10 @@ func baseAdapter(kind string, idx int, tc config.Transport, s *store.SQLiteStore
 		remoteToChannel: remoteToChannel,
 		buses:           buses,
 		store:           s,
+		log:             logger,
+		metrics:         m,
 		connectFn:       func(context.Context) error { return nil },
-		sessionFn:       consumeOnlySession(buses),
+		sessionFn:       consumeOnlySession(buses, logger, m),
 	}
 }
 
@@ -105,12 +138,18 @@ func cloneMap(in map[string]string) map[string]string {
 	return out
 }
 
-func consumeOnlySession(buses []string) func(context.Context, core.RuntimeAPI) error {
+func consumeOnlySession(buses []string, logger *slog.Logger, m *telemetry.Metrics) func(context.Context, core.RuntimeAPI) error {
 	return func(ctx context.Context, api core.RuntimeAPI) error {
 		var wg sync.WaitGroup
 		for _, busID := range buses {
 			sub, err := api.Subscribe(ctx, busID, 64)
 			if err != nil {
+				if m != nil {
+					m.IncForwardingFail()
+				}
+				if logger != nil {
+					logger.Error("subscribe failed", "bus_id", busID, "error", err)
+				}
 				return err
 			}
 			wg.Add(1)
@@ -134,32 +173,32 @@ func consumeOnlySession(buses []string) func(context.Context, core.RuntimeAPI) e
 	}
 }
 
-func buildSlack(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
-	t := baseAdapter("Slack", idx, tc, s)
+func buildSlack(idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) core.Transport {
+	t := baseAdapter("Slack", idx, tc, s, logger, m)
 	t.connectFn = func(context.Context) error { return nil }
 	return t
 }
 
-func buildDiscord(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
-	t := baseAdapter("Discord", idx, tc, s)
+func buildDiscord(idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) core.Transport {
+	t := baseAdapter("Discord", idx, tc, s, logger, m)
 	t.connectFn = func(context.Context) error { return nil }
 	return t
 }
 
-func buildIRC(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
-	t := baseAdapter("IRC", idx, tc, s)
+func buildIRC(idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) core.Transport {
+	t := baseAdapter("IRC", idx, tc, s, logger, m)
 	t.connectFn = func(context.Context) error { return nil }
 	return t
 }
 
-func buildMumble(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
-	t := baseAdapter("Mumble", idx, tc, s)
+func buildMumble(idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) core.Transport {
+	t := baseAdapter("Mumble", idx, tc, s, logger, m)
 	t.connectFn = func(context.Context) error { return nil }
 	return t
 }
 
-func buildRachni(idx int, tc config.Transport, s *store.SQLiteStore) core.Transport {
-	t := baseAdapter("Rachni", idx, tc, s)
+func buildRachni(idx int, tc config.Transport, s *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) core.Transport {
+	t := baseAdapter("Rachni", idx, tc, s, logger, m)
 	t.buses = append([]string(nil), tc.Buses...)
 	t.connectFn = func(context.Context) error { return nil }
 	return t

--- a/internal/transports/factory.go
+++ b/internal/transports/factory.go
@@ -3,15 +3,17 @@ package transports
 import (
 	"fmt"
 	"iter"
+	"log/slog"
 	"maps"
 	"slices"
 
 	"github.com/nemored/pipo/internal/config"
 	"github.com/nemored/pipo/internal/core"
 	"github.com/nemored/pipo/internal/store"
+	"github.com/nemored/pipo/internal/telemetry"
 )
 
-func Build(cfg config.ParsedConfig, db *store.SQLiteStore) ([]core.Transport, error) {
+func Build(cfg config.ParsedConfig, db *store.SQLiteStore, logger *slog.Logger, m *telemetry.Metrics) ([]core.Transport, error) {
 	knownBuses := make(map[string]struct{}, len(cfg.Buses))
 	for _, bus := range cfg.Buses {
 		knownBuses[bus.ID] = struct{}{}
@@ -31,15 +33,15 @@ func Build(cfg config.ParsedConfig, db *store.SQLiteStore) ([]core.Transport, er
 		}
 		switch tc.Kind {
 		case "Slack":
-			out = append(out, buildSlack(idx, tc, db))
+			out = append(out, buildSlack(idx, tc, db, logger, m))
 		case "Discord":
-			out = append(out, buildDiscord(idx, tc, db))
+			out = append(out, buildDiscord(idx, tc, db, logger, m))
 		case "IRC":
-			out = append(out, buildIRC(idx, tc, db))
+			out = append(out, buildIRC(idx, tc, db, logger, m))
 		case "Mumble":
-			out = append(out, buildMumble(idx, tc, db))
+			out = append(out, buildMumble(idx, tc, db, logger, m))
 		case "Rachni":
-			out = append(out, buildRachni(idx, tc, db))
+			out = append(out, buildRachni(idx, tc, db, logger, m))
 		case "Minecraft":
 			out = append(out, notImplementedTransport{name: fmt.Sprintf("%s[%d]", tc.Kind, idx)})
 		default:

--- a/internal/transports/factory_test.go
+++ b/internal/transports/factory_test.go
@@ -26,7 +26,7 @@ func TestBuildConstructsTypedAdapters(t *testing.T) {
 	}
 	defer s.Close()
 
-	got, err := Build(cfg, s)
+	got, err := Build(cfg, s, nil, nil)
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}


### PR DESCRIPTION
### Motivation
- Provide a safe staged rollout path (shadow → partial → full) for the Go rewrite with a clear rollback to the Rust binary without destructive migrations. 
- Add runtime observability so deployments can be gated on concrete connect/queue/forwarding/DB health signals.

### Description
- Introduce `internal/telemetry` with a JSON logger helper and atomic counters for `connect_attempts`, `connect_successes`, `connect_failures`, `queue_pressure_drops`, `forwarding_failures`, and `db_errors` and a `Snapshot()` exporter. (`internal/telemetry/telemetry.go`).
- Wire structured logs and metrics into the runtime and broker so transport lifecycle events and queue-pressure drops emit JSON logs and update counters (`internal/core/runtime.go`, `internal/core/bus.go`).
- Instrument transport adapters to record connect lifecycle and forwarding/session failures, and propagate logs/metrics there (`internal/transports/adapters.go`, `internal/transports/factory.go`).
- Add a DB error observer API and instrument SQLite store operations to report DB errors through that observer (`internal/store/observe.go`, `internal/store/sqlite.go`), and hook the observer in the CLI to increment metrics and log DB errors (`cmd/pipo/main.go`).
- Add an optional health server that serves `/healthz` (enabled via `HEALTH_ADDR`) returning `status=ok` and the metric snapshot, and add rollout/rollback documentation describing the three-stage plan and continuity guarantees (`cmd/pipo/main.go`, `docs/go-rollout-deployment-plan.md`).
- Updated factory and test signatures to pass logger/metrics where needed and adjusted unit tests accordingly (`internal/transports/factory_test.go`, `internal/core/bus_test.go`).

### Testing
- Formatted changed files with `gofmt -w` on modified sources. 
- Ran unit tests with `go test ./...` and observed a successful run (all tested packages passed, command exited `0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c4eceb3483318fa647db9823af71)