### PR TITLE
Run PR CI on all feature branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'feature/matrix'
-      - 'feature/elixir-supervisor'
+      - 'feature/**'
 
 jobs:
   build:


### PR DESCRIPTION
### Motivation
- Enable the repository's PR CI to run for all current and future feature branches by replacing hard-coded feature branch names with a wildcard.

### Description
- Update `.github/workflows/build.yml` to replace the two specific `feature/matrix` and `feature/elixir-supervisor` entries with a single `feature/**` wildcard under `pull_request.branches`.

### Testing
- Verified the change with `git diff -- .github/workflows/build.yml` and inspected the file with `nl -ba .github/workflows/build.yml | sed -n '1,30p'`, both showing the updated `feature/**` entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b882ee51fc8331b409d5e40d3d9c1a)