### PR TITLE
Implement IRC-native formatting serialization in Slack rich text renderer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,7 @@ enum ConfigTransport {
     Slack {
         token: Arc<String>,
         bot_token: Arc<String>,
+        irc_formatting_enabled: Option<bool>,
         channel_mapping: HashMap<Arc<String>, Arc<String>>,
     },
     Minecraft {
@@ -437,6 +438,7 @@ pub async fn inner_main() -> anyhow::Result<()> {
             ConfigTransport::Slack {
                 token,
                 bot_token,
+                irc_formatting_enabled,
                 channel_mapping,
             } => {
                 let mut instance = Slack::new(
@@ -446,6 +448,7 @@ pub async fn inner_main() -> anyhow::Result<()> {
                     db_pool.clone(),
                     token.to_string(),
                     bot_token.to_string(),
+                    irc_formatting_enabled.unwrap_or(true),
                     &channel_mapping,
                 )
                 .await?;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -28,7 +28,7 @@ use crate::Message;
 pub mod objects;
 mod rich_text_renderer;
 use objects::{Message as SlackMessage, *};
-use rich_text_renderer::RichTextResolver;
+use rich_text_renderer::{RenderOptions, RichTextResolver};
 //mod parse;
 //use parse::*;
 
@@ -47,6 +47,7 @@ pub(crate) struct Slack {
     id_map: HashMap<String, String>,
     users: HashMap<String, User>,
     seen_event_ids: VecDeque<String>,
+    irc_formatting_enabled: bool,
 }
 
 struct WebSocket {
@@ -64,6 +65,7 @@ impl Slack {
         pool: Pool,
         token: String,
         bot_token: String,
+        irc_formatting_enabled: bool,
         channel_mapping: &HashMap<Arc<String>, Arc<String>>,
     ) -> anyhow::Result<Slack> {
         let channels = channel_mapping
@@ -96,6 +98,7 @@ impl Slack {
             id_map: HashMap::new(),
             users: HashMap::new(),
             seen_event_ids: VecDeque::with_capacity(50),
+            irc_formatting_enabled,
         })
     }
 
@@ -2312,7 +2315,14 @@ impl Slack {
     }
 
     async fn convert_element_to_string(&mut self, element: &Element) -> anyhow::Result<String> {
-        rich_text_renderer::render(self, element).await
+        rich_text_renderer::render(
+            self,
+            element,
+            RenderOptions {
+                irc_formatting_enabled: self.irc_formatting_enabled,
+            },
+        )
+        .await
     }
 
     async fn parse_usernames(&mut self, text: &str) -> anyhow::Result<String> {

--- a/src/slack/rich_text_renderer.rs
+++ b/src/slack/rich_text_renderer.rs
@@ -4,6 +4,40 @@ use serenity::async_trait;
 
 use super::objects::{Element, Style};
 
+const IRC_BOLD: char = '\u{0002}';
+const IRC_ITALIC: char = '\u{001d}';
+const IRC_MONOSPACE: char = '\u{0011}';
+const IRC_STRIKETHROUGH: char = '\u{001e}';
+const IRC_RESET: char = '\u{000f}';
+
+const IRC_STYLE_STACK: &[(IrcStyle, char)] = &[
+    (IrcStyle::Bold, IRC_BOLD),
+    (IrcStyle::Italic, IRC_ITALIC),
+    (IrcStyle::Strikethrough, IRC_STRIKETHROUGH),
+    (IrcStyle::Monospace, IRC_MONOSPACE),
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IrcStyle {
+    Bold,
+    Italic,
+    Strikethrough,
+    Monospace,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RenderOptions {
+    pub irc_formatting_enabled: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            irc_formatting_enabled: true,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RichTextNode {
     Section(Vec<RichTextNode>),
@@ -195,44 +229,42 @@ fn split_text_with_line_breaks(text: &str) -> Vec<RichTextNode> {
     nodes
 }
 
-pub async fn render<R>(resolver: &mut R, element: &Element) -> Result<String>
+pub async fn render<R>(
+    resolver: &mut R,
+    element: &Element,
+    options: RenderOptions,
+) -> Result<String>
 where
     R: RichTextResolver + Send,
 {
-    render_node(resolver, &build_ir(element)).await
+    render_node(resolver, &build_ir(element), options).await
 }
 
 #[async_recursion]
-pub async fn render_node<R>(resolver: &mut R, node: &RichTextNode) -> Result<String>
+pub async fn render_node<R>(
+    resolver: &mut R,
+    node: &RichTextNode,
+    options: RenderOptions,
+) -> Result<String>
 where
     R: RichTextResolver + Send,
 {
     match node {
-        RichTextNode::Section(children) => render_children(resolver, children).await,
-        RichTextNode::PlainText(text) => Ok(text.clone()),
+        RichTextNode::Section(children) => render_children(resolver, children, options).await,
+        RichTextNode::PlainText(text) => Ok(sanitize_irc_conflicts(text)),
         RichTextNode::StyleSpan {
             bold,
             italic,
             strike,
             children,
         } => {
-            let body = render_children(resolver, children).await?;
-            if *strike {
-                return Ok(format!("~~{}~~", body));
-            }
-
-            let mut prefix = String::new();
-            let mut suffix = String::new();
-            if *bold {
-                prefix.push_str("**");
-                suffix = format!("**{}", suffix);
-            }
-            if *italic {
-                prefix.push('*');
-                suffix = format!("*{}", suffix);
-            }
-
-            Ok(format!("{}{}{}", prefix, body, suffix))
+            let body = render_children(resolver, children, options).await?;
+            let styles = [
+                (*bold, IrcStyle::Bold),
+                (*italic, IrcStyle::Italic),
+                (*strike, IrcStyle::Strikethrough),
+            ];
+            Ok(apply_irc_styles(&body, &styles, options))
         }
         RichTextNode::LineBreak => Ok("\n".to_string()),
         RichTextNode::List {
@@ -252,20 +284,28 @@ where
                     "{}{} {}\n",
                     indent_str,
                     bullet,
-                    render_node(resolver, item).await?
+                    render_node(resolver, item, options).await?
                 ));
             }
             Ok(rendered)
         }
         RichTextNode::QuoteBlock(children) => Ok(format!(
             ">>> {}",
-            render_children(resolver, children).await?
+            render_children(resolver, children, options).await?
         )),
-        RichTextNode::CodeSpan(text) => Ok(format!("`{}`", text)),
-        RichTextNode::CodeBlock(children) => Ok(format!(
-            "```{}```",
-            render_children(resolver, children).await?
+        RichTextNode::CodeSpan(text) => Ok(apply_irc_styles(
+            &sanitize_irc_conflicts(text),
+            &[(true, IrcStyle::Monospace)],
+            options,
         )),
+        RichTextNode::CodeBlock(children) => {
+            let body = render_children(resolver, children, options).await?;
+            Ok(apply_irc_styles(
+                &body,
+                &[(true, IrcStyle::Monospace)],
+                options,
+            ))
+        }
         RichTextNode::Mention(Mention::User(user_id)) => Ok(format!(
             "@{}",
             resolver.resolve_user_display_name(user_id).await?
@@ -281,20 +321,65 @@ where
         RichTextNode::Mention(Mention::Usergroup(usergroup_id)) => {
             Ok(format!("<!subteam^{}>", usergroup_id))
         }
-        RichTextNode::Link { url, text } => Ok(text.clone().unwrap_or_else(|| url.clone())),
+        RichTextNode::Link { url, text } => Ok(sanitize_irc_conflicts(
+            &text.clone().unwrap_or_else(|| url.clone()),
+        )),
         RichTextNode::Emoji(name) => Ok(format!(":{}:", name)),
-        RichTextNode::Date(fallback) => Ok(fallback.clone()),
-        RichTextNode::Unsupported(desc) => Ok(format!("[{}]", desc)),
+        RichTextNode::Date(fallback) => Ok(sanitize_irc_conflicts(fallback)),
+        RichTextNode::Unsupported(desc) => Ok(format!("[{}]", sanitize_irc_conflicts(desc))),
     }
 }
 
-async fn render_children<R>(resolver: &mut R, children: &[RichTextNode]) -> Result<String>
+fn apply_irc_styles(body: &str, styles: &[(bool, IrcStyle)], options: RenderOptions) -> String {
+    if body.is_empty() {
+        return String::new();
+    }
+
+    if !options.irc_formatting_enabled {
+        return body.to_string();
+    }
+
+    let mut prefix = String::new();
+    for (style, code) in IRC_STYLE_STACK {
+        if styles
+            .iter()
+            .any(|(enabled, current)| *enabled && current == style)
+        {
+            prefix.push(*code);
+        }
+    }
+
+    if prefix.is_empty() {
+        body.to_string()
+    } else {
+        format!("{prefix}{body}{IRC_RESET}")
+    }
+}
+
+fn sanitize_irc_conflicts(input: &str) -> String {
+    input
+        .chars()
+        .filter(|ch| {
+            *ch != IRC_BOLD
+                && *ch != IRC_ITALIC
+                && *ch != IRC_MONOSPACE
+                && *ch != IRC_STRIKETHROUGH
+                && *ch != IRC_RESET
+        })
+        .collect()
+}
+
+async fn render_children<R>(
+    resolver: &mut R,
+    children: &[RichTextNode],
+    options: RenderOptions,
+) -> Result<String>
 where
     R: RichTextResolver + Send,
 {
     let mut rendered = String::new();
     for child in children {
-        rendered.push_str(&render_node(resolver, child).await?);
+        rendered.push_str(&render_node(resolver, child, options).await?);
     }
     Ok(rendered)
 }
@@ -330,7 +415,9 @@ mod tests {
         };
 
         let mut resolver = TestResolver;
-        let rendered = render(&mut resolver, &element).await.unwrap();
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
         assert_eq!(rendered, "\t1. @user-U123\n");
     }
 
@@ -349,7 +436,66 @@ mod tests {
         };
 
         let mut resolver = TestResolver;
-        let rendered = render(&mut resolver, &element).await.unwrap();
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
         assert!(rendered.contains("unsupported element"));
+    }
+
+    #[tokio::test]
+    async fn renders_irc_style_codes() {
+        let element = Element::Text {
+            text: " hi ".to_string(),
+            style: Some(Style {
+                bold: Some(true),
+                italic: Some(true),
+                strike: Some(false),
+                code: Some(false),
+            }),
+        };
+
+        let mut resolver = TestResolver;
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(rendered, " \u{0002}\u{001d}hi\u{000f} ");
+    }
+
+    #[tokio::test]
+    async fn strips_embedded_irc_control_codes_from_plaintext() {
+        let element = Element::Text {
+            text: format!("bad{}text{}", '\u{0002}', '\u{001d}'),
+            style: None,
+        };
+
+        let mut resolver = TestResolver;
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(rendered, "badtext");
+    }
+    #[tokio::test]
+    async fn can_disable_irc_style_codes() {
+        let element = Element::Text {
+            text: " hi ".to_string(),
+            style: Some(Style {
+                bold: Some(true),
+                italic: Some(true),
+                strike: Some(false),
+                code: Some(false),
+            }),
+        };
+
+        let mut resolver = TestResolver;
+        let rendered = render(
+            &mut resolver,
+            &element,
+            RenderOptions {
+                irc_formatting_enabled: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(rendered, " hi ");
     }
 }


### PR DESCRIPTION
### Motivation
- Emit IRC-native control codes instead of Markdown markers so Slack rich-text output can be rendered natively on IRC clients while preserving existing whitespace semantics.
- Prevent accidental client-side formatting breakage by sanitizing incoming text for embedded IRC control bytes.
- Provide a compatibility/fallback mechanism so IRC formatting can be disabled via configuration when plain text is required.

### Description
- Added IRC control-character constants, an `IrcStyle` enum and a `RenderOptions` struct with an `irc_formatting_enabled` flag to control behavior at render time.
- Replaced Markdown marker emission in `render_node` with `apply_irc_styles` that emits stacked IRC control codes and terminates styled content with the IRC reset code.
- Preserved the existing leading/trailing whitespace handling in `styled_text_to_nodes` so spaces remain outside style wrappers, and added `sanitize_irc_conflicts` to strip embedded control codes from plaintext and link/date/unsupported outputs.
- Plumbed the `irc_formatting_enabled` option through config (`ConfigTransport::Slack` now accepts `irc_formatting_enabled`) and the Slack transport instance so the renderer can fall back to plain text; added unit tests covering IRC code emission, sanitization, and the disable-fallback.

### Testing
- Ran the renderer unit tests with `cargo test slack::rich_text_renderer::tests:: -- --nocapture` and all tests in that module passed.
- Ran the new unit tests `renders_irc_style_codes`, `strips_embedded_irc_control_codes_from_plaintext`, and `can_disable_irc_style_codes` and they succeeded.
- Ran `rustfmt` on modified files and used `rustfmt`/`cargo test` locally for validation; full-crate `cargo fmt --all` failed here due to an unrelated missing generated module but tests for the modified renderer passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8902311548331b6b484af2f020e2d)