### PR TITLE
Use `Url::parse_with_params` for Slack GET requests and pin `windows-sys` to 0.59.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2456,7 +2456,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3139,7 +3139,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1102,10 +1102,14 @@ impl Slack {
                     ("Bearer ".to_owned() + &self.bot_token).parse()?,
                 );
 
+                let url = reqwest::Url::parse_with_params(
+                    "https://slack.com/api/users.profile.get",
+                    &[("user", user.as_str())],
+                )?;
+
                 let response = self
                     .http
-                    .request(Method::GET, "https://slack.com/api/users.profile.get")
-                    .query(&[("user", user)])
+                    .request(Method::GET, url)
                     .headers(headers)
                     .send()
                     .await?;
@@ -1151,20 +1155,23 @@ impl Slack {
         );
 
         while paginate {
-            let mut query = Vec::new();
-            let request = self
-                .http
-                .request(Method::GET, "https://slack.com/api/users.list")
-                .headers(headers.clone())
-                .query(&query);
-
-            query.push(("limit", "100"));
+            let mut query = vec![("limit", "100")];
             if !cursor.is_empty() {
-                query.push(("cursor", &cursor));
+                query.push(("cursor", cursor.as_str()));
             }
 
-            let users_list: UsersList =
-                serde_json::from_str(request.send().await?.text().await?.as_str())?;
+            let url = reqwest::Url::parse_with_params("https://slack.com/api/users.list", &query)?;
+
+            let users_list: UsersList = serde_json::from_str(
+                self.http
+                    .request(Method::GET, url)
+                    .headers(headers.clone())
+                    .send()
+                    .await?
+                    .text()
+                    .await?
+                    .as_str(),
+            )?;
 
             if let Some(members) = users_list.members {
                 for user in members {
@@ -2500,16 +2507,20 @@ impl Slack {
             format!("Bearer {}", self.bot_token).parse()?,
         );
 
+        let url = reqwest::Url::parse_with_params(
+            "https://slack.com/api/conversations.history",
+            &[
+                ("channel", channel),
+                ("inclusive", "true"),
+                ("latest", ts.0.as_str()),
+                ("limit", "1"),
+            ],
+        )?;
+
         let response = self
             .http
-            .request(Method::GET, "https://slack.com/api/conversations.history")
+            .request(Method::GET, url)
             .headers(headers)
-            .query(&[
-                ("channel", channel.to_string()),
-                ("inclusive", String::from("true")),
-                ("latest", ts.0.clone()),
-                ("limit", String::from("1")),
-            ])
             .send()
             .await?;
 
@@ -2544,11 +2555,12 @@ impl Slack {
             format!("Bearer {}", self.bot_token).parse()?,
         );
 
+        let url = reqwest::Url::parse_with_params("https://slack.com/api/users.info", &[("user", user)])?;
+
         let response = self
             .http
-            .request(Method::GET, "https://slack.com/api/users.info")
+            .request(Method::GET, url)
             .headers(headers)
-            .query(&[("user", user.to_string())])
             .send()
             .await?;
 


### PR DESCRIPTION
### Motivation

- Ensure GET requests to Slack APIs build query parameters with owned/escaped URL values to avoid lifetime/typing issues and make request construction clearer.
- Stabilize dependency resolution by aligning several crates on `windows-sys` version `0.59.0` in the lockfile.

### Description

- Replace uses of `.query(...)` and manual `Vec` query construction with `reqwest::Url::parse_with_params` in Slack client methods `get_user_display_name`, `get_users_list`, `get_message`, and `get_user_info` to build full request URLs with parameters before calling `.request(...)`.
- Simplify `get_users_list` query setup by initializing the `limit` param directly and passing `cursor` as a `&str` when present.
- Refactor request flows to call `.request(Method::GET, url)` with the parsed URL and keep header handling unchanged.
- Update `Cargo.lock` entries to use `windows-sys = "0.59.0"` where previously `0.61.2` appeared, aligning transitive dependencies.

### Testing

- Ran `cargo build` on the modified workspace and the build completed successfully.
- Ran `cargo test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8947d4dd08331b9c2fc317fcb1cf6)