### PR TITLE
Unify Slack entity resolution for rich-text and plain-text paths

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -25,8 +25,13 @@ use tokio_tungstenite::*;
 
 use crate::Message;
 
+mod entity_resolver;
 pub mod objects;
 mod rich_text_renderer;
+use entity_resolver::{
+    format_broadcast, format_channel, format_link, format_team, format_user, format_usergroup,
+    parse_entity_reference, EntityReference,
+};
 use objects::{Message as SlackMessage, *};
 use rich_text_renderer::{RenderOptions, RichTextResolver};
 //mod parse;
@@ -46,6 +51,7 @@ pub(crate) struct Slack {
     channel_map: HashMap<String, String>,
     id_map: HashMap<String, String>,
     users: HashMap<String, User>,
+    user_id_map: HashMap<String, String>,
     seen_event_ids: VecDeque<String>,
     irc_formatting_enabled: bool,
 }
@@ -97,6 +103,7 @@ impl Slack {
             channel_map: HashMap::new(),
             id_map: HashMap::new(),
             users: HashMap::new(),
+            user_id_map: HashMap::new(),
             seen_event_ids: VecDeque::with_capacity(50),
             irc_formatting_enabled,
         })
@@ -1094,51 +1101,73 @@ impl Slack {
     }
 
     async fn get_user_display_name(&mut self, user: Option<String>) -> anyhow::Result<String> {
-        let display_name = match user {
-            Some(user) => {
-                let mut headers = HeaderMap::new();
-
-                headers.insert(
-                    header::CONTENT_TYPE,
-                    "application/x-www-form-urlencoded".parse()?,
-                );
-                headers.insert(
-                    header::AUTHORIZATION,
-                    ("Bearer ".to_owned() + &self.bot_token).parse()?,
-                );
-
-                let response = self
-                    .http
-                    .request(Method::GET, "https://slack.com/api/users.profile.get")
-                    .query(&[("user", user)])
-                    .headers(headers)
-                    .send()
-                    .await?;
-                let json: Value = serde_json::from_str(response.text().await?.as_str())?;
-                if json["ok"] == false {
-                    return Err(anyhow!("get_user_display_name() {:?}", json));
-                }
-
-                match json["profile"].get("display_name").unwrap().as_str() {
-                    Some("") => json["profile"]
-                        .get("real_name")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .to_string(),
-                    Some(s) => s.to_string(),
-                    None => json["profile"]
-                        .get("real_name")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .to_string(),
-                }
-            }
-            None => "".to_string(),
+        let Some(user_id) = user else {
+            return Ok(String::new());
         };
 
-        Ok(display_name.to_string())
+        if let Some(name) = self.user_id_map.get(&user_id) {
+            return Ok(name.clone());
+        }
+
+        for user in self.users.values() {
+            if user.id.as_deref() == Some(user_id.as_str()) {
+                if let Some(name) = user
+                    .profile
+                    .as_ref()
+                    .and_then(|profile| profile.display_name.as_ref())
+                    .filter(|name| !name.is_empty())
+                    .cloned()
+                    .or_else(|| user.real_name.clone())
+                    .or_else(|| user.name.clone())
+                {
+                    self.user_id_map.insert(user_id.clone(), name.clone());
+                    return Ok(name);
+                }
+            }
+        }
+
+        let mut headers = HeaderMap::new();
+
+        headers.insert(
+            header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded".parse()?,
+        );
+        headers.insert(
+            header::AUTHORIZATION,
+            ("Bearer ".to_owned() + &self.bot_token).parse()?,
+        );
+
+        let response = self
+            .http
+            .request(Method::GET, "https://slack.com/api/users.profile.get")
+            .query(&[("user", user_id.clone())])
+            .headers(headers)
+            .send()
+            .await?;
+        let json: Value = serde_json::from_str(response.text().await?.as_str())?;
+        if json["ok"] == false {
+            return Err(anyhow!("get_user_display_name() {:?}", json));
+        }
+
+        let display_name = match json["profile"].get("display_name").unwrap().as_str() {
+            Some("") => json["profile"]
+                .get("real_name")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+            Some(s) => s.to_string(),
+            None => json["profile"]
+                .get("real_name")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string(),
+        };
+
+        self.user_id_map.insert(user_id, display_name.clone());
+
+        Ok(display_name)
     }
 
     async fn get_users_list(&mut self) -> anyhow::Result<()> {
@@ -1173,6 +1202,20 @@ impl Slack {
 
             if let Some(members) = users_list.members {
                 for user in members {
+                    if let Some(id) = user.id.clone() {
+                        if let Some(display_name) = user
+                            .profile
+                            .as_ref()
+                            .and_then(|profile| profile.display_name.as_ref())
+                            .filter(|name| !name.is_empty())
+                            .cloned()
+                            .or_else(|| user.real_name.clone())
+                            .or_else(|| user.name.clone())
+                        {
+                            self.user_id_map.insert(id, display_name);
+                        }
+                    }
+
                     if let Some(ref name) = user.name {
                         self.users.insert(name.to_string(), user);
                     } else if let Some(ref name) = user.real_name {
@@ -2327,29 +2370,48 @@ impl Slack {
 
     async fn parse_usernames(&mut self, text: &str) -> anyhow::Result<String> {
         lazy_static! {
-            static ref RE: Regex = Regex::new("<(@[A-Z0-9]+)\\|*([^>]*)>").unwrap();
+            static ref ENTITY_RE: Regex = Regex::new("<([^>]+)>").unwrap();
         }
 
-        let mut name_map = HashMap::new();
+        let mut output = String::with_capacity(text.len());
+        let mut last = 0;
 
-        for captures in RE.captures_iter(text) {
-            let user = captures.get(1).unwrap().as_str();
-            if let Some(name) = captures.get(2) {
-                name_map.insert(user, name.as_str().to_string());
-            } else {
-                let name = self.get_user_display_name(Some(user.to_string())).await?;
-                name_map.insert(user, name);
-            }
+        for captures in ENTITY_RE.captures_iter(text) {
+            let full = captures.get(0).unwrap();
+            let inner = captures.get(1).unwrap().as_str();
+
+            output.push_str(&text[last..full.start()]);
+            last = full.end();
+
+            let replacement = match parse_entity_reference(inner) {
+                EntityReference::User { id, label } => {
+                    let label = match label.filter(|label| !label.is_empty()) {
+                        Some(label) => Some(label),
+                        None => self.get_user_display_name(Some(id.clone())).await.ok(),
+                    };
+                    format_user(label.as_deref(), &id)
+                }
+                EntityReference::Channel { id, label } => {
+                    let channel_name = label.or_else(|| self.id_map.get(&id).cloned());
+                    format_channel(channel_name.as_deref(), &id)
+                }
+                EntityReference::Team { id, label } => {
+                    format_team(label.as_deref().filter(|label| !label.is_empty()), &id)
+                }
+                EntityReference::Usergroup { id, label } => {
+                    format_usergroup(label.as_deref().filter(|label| !label.is_empty()), &id)
+                }
+                EntityReference::Broadcast { range, .. } => format_broadcast(&range),
+                EntityReference::Link { url, label } => format_link(&url, label.as_deref()),
+                EntityReference::Unknown { raw } => format!("<{raw}>"),
+            };
+
+            output.push_str(&replacement);
         }
 
-        Ok(RE
-            .replace_all(&text, |captures: &Captures| -> String {
-                format!(
-                    "@{}",
-                    name_map.get(captures.get(1).unwrap().as_str()).unwrap()
-                )
-            })
-            .to_string())
+        output.push_str(&text[last..]);
+
+        Ok(output)
     }
 
     async fn get_message(&self, channel: &str, ts: &Timestamp) -> anyhow::Result<SlackMessage> {

--- a/src/slack/entity_resolver.rs
+++ b/src/slack/entity_resolver.rs
@@ -1,0 +1,143 @@
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum EntityReference {
+    User {
+        id: String,
+        label: Option<String>,
+    },
+    Channel {
+        id: String,
+        label: Option<String>,
+    },
+    Team {
+        id: String,
+        label: Option<String>,
+    },
+    Usergroup {
+        id: String,
+        label: Option<String>,
+    },
+    Broadcast {
+        range: String,
+        label: Option<String>,
+    },
+    Link {
+        url: String,
+        label: Option<String>,
+    },
+    Unknown {
+        raw: String,
+    },
+}
+
+pub(crate) fn parse_entity_reference(raw: &str) -> EntityReference {
+    if let Some(rest) = raw.strip_prefix('@') {
+        let (id, label) = split_id_and_label(rest);
+        return EntityReference::User { id, label };
+    }
+
+    if let Some(rest) = raw.strip_prefix('#') {
+        let (id, label) = split_id_and_label(rest);
+        return EntityReference::Channel { id, label };
+    }
+
+    if let Some(rest) = raw.strip_prefix("!subteam^") {
+        let (id, label) = split_id_and_label(rest);
+        return EntityReference::Usergroup { id, label };
+    }
+
+    if let Some(rest) = raw.strip_prefix("!team^") {
+        let (id, label) = split_id_and_label(rest);
+        return EntityReference::Team { id, label };
+    }
+
+    if let Some(rest) = raw.strip_prefix('!') {
+        let (range, label) = split_id_and_label(rest);
+        return EntityReference::Broadcast { range, label };
+    }
+
+    let (url, label) = split_id_and_label(raw);
+    if url.contains("://") || url.starts_with("mailto:") {
+        return EntityReference::Link { url, label };
+    }
+
+    EntityReference::Unknown {
+        raw: raw.to_string(),
+    }
+}
+
+pub(crate) fn format_user(name: Option<&str>, user_id: &str) -> String {
+    format!("@{}", name.unwrap_or(&unknown_placeholder("user", user_id)))
+}
+
+pub(crate) fn format_channel(name: Option<&str>, channel_id: &str) -> String {
+    format!(
+        "#{}",
+        name.unwrap_or(&unknown_placeholder("channel", channel_id))
+    )
+}
+
+pub(crate) fn format_team(name: Option<&str>, team_id: &str) -> String {
+    format!("@{}", name.unwrap_or(&unknown_placeholder("team", team_id)))
+}
+
+pub(crate) fn format_usergroup(name: Option<&str>, usergroup_id: &str) -> String {
+    format!(
+        "@{}",
+        name.unwrap_or(&unknown_placeholder("usergroup", usergroup_id))
+    )
+}
+
+pub(crate) fn format_broadcast(range: &str) -> String {
+    match range {
+        "here" | "channel" | "everyone" => format!("@{range}"),
+        _ => format!("@{}", unknown_placeholder("broadcast", range)),
+    }
+}
+
+pub(crate) fn format_link(url: &str, label: Option<&str>) -> String {
+    match label.map(str::trim).filter(|label| !label.is_empty()) {
+        Some(label) if label != url => format!("{} ({})", label, url),
+        _ => url.to_string(),
+    }
+}
+
+pub(crate) fn unknown_placeholder(entity: &str, id: &str) -> String {
+    format!("unknown-{entity}:{id}")
+}
+
+fn split_id_and_label(value: &str) -> (String, Option<String>) {
+    match value.split_once('|') {
+        Some((id, label)) => (id.to_string(), Some(label.to_string())),
+        None => (value.to_string(), None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_links_with_and_without_label() {
+        assert_eq!(
+            format_link("https://example.com", Some("Example")),
+            "Example (https://example.com)"
+        );
+        assert_eq!(
+            format_link("https://example.com", None),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn parses_entity_types() {
+        assert_eq!(
+            parse_entity_reference("@U123|alice"),
+            EntityReference::User {
+                id: "U123".to_string(),
+                label: Some("alice".to_string())
+            }
+        );
+        assert_eq!(format_broadcast("here"), "@here");
+        assert_eq!(format_broadcast("unknown"), "@unknown-broadcast:unknown");
+    }
+}

--- a/src/slack/rich_text_renderer.rs
+++ b/src/slack/rich_text_renderer.rs
@@ -2,7 +2,12 @@ use anyhow::Result;
 use async_recursion::async_recursion;
 use serenity::async_trait;
 
-use super::objects::{Element, Style};
+use super::{
+    entity_resolver::{
+        format_broadcast, format_channel, format_link, format_team, format_user, format_usergroup,
+    },
+    objects::{Element, Style},
+};
 
 const IRC_BOLD: char = '\u{0002}';
 const IRC_ITALIC: char = '\u{001d}';
@@ -332,24 +337,22 @@ where
             let body = render_children(resolver, children, raw_options).await?;
             Ok(format!("```\n{}\n```", sanitize_irc_conflicts(&body)))
         }
-        RichTextNode::Mention(Mention::User(user_id)) => Ok(format!(
-            "@{}",
-            resolver.resolve_user_display_name(user_id).await?
-        )),
+        RichTextNode::Mention(Mention::User(user_id)) => {
+            let user_name = resolver.resolve_user_display_name(user_id).await.ok();
+            Ok(format_user(user_name.as_deref(), user_id))
+        }
         RichTextNode::Mention(Mention::Channel(channel_id)) => {
-            let channel = resolver
-                .resolve_channel_name(channel_id)
-                .unwrap_or_else(|| "Unknown".to_string());
-            Ok(format!("#{}", channel))
+            let channel_name = resolver.resolve_channel_name(channel_id);
+            Ok(format_channel(channel_name.as_deref(), channel_id))
         }
-        RichTextNode::Mention(Mention::Broadcast(range)) => Ok(format!("<!{}>", range)),
-        RichTextNode::Mention(Mention::Team(team_id)) => Ok(format!("<!team^{}>", team_id)),
+        RichTextNode::Mention(Mention::Broadcast(range)) => Ok(format_broadcast(range)),
+        RichTextNode::Mention(Mention::Team(team_id)) => Ok(format_team(None, team_id)),
         RichTextNode::Mention(Mention::Usergroup(usergroup_id)) => {
-            Ok(format!("<!subteam^{}>", usergroup_id))
+            Ok(format_usergroup(None, usergroup_id))
         }
-        RichTextNode::Link { url, text } => Ok(sanitize_irc_conflicts(
-            &text.clone().unwrap_or_else(|| url.clone()),
-        )),
+        RichTextNode::Link { url, text } => {
+            Ok(sanitize_irc_conflicts(&format_link(url, text.as_deref())))
+        }
         RichTextNode::Emoji(name) => Ok(format!(":{}:", name)),
         RichTextNode::Date(fallback) => Ok(sanitize_irc_conflicts(fallback)),
         RichTextNode::Unsupported(desc) => Ok(format!("[{}]", sanitize_irc_conflicts(desc))),
@@ -565,6 +568,57 @@ mod tests {
         assert_eq!(rendered, " hi ");
     }
 
+    #[tokio::test]
+    async fn renders_link_label_with_url() {
+        let element = Element::Link {
+            url: "https://example.com".to_string(),
+            text: Some("Example".to_string()),
+            style: None,
+        };
+
+        let mut resolver = TestResolver;
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(rendered, "Example (https://example.com)");
+    }
+
+    #[tokio::test]
+    async fn renders_unknown_mentions_deterministically() {
+        struct UnknownResolver;
+
+        #[async_trait]
+        impl RichTextResolver for UnknownResolver {
+            async fn resolve_user_display_name(&mut self, _user_id: &str) -> Result<String> {
+                Err(anyhow::anyhow!("not found"))
+            }
+
+            fn resolve_channel_name(&self, _channel_id: &str) -> Option<String> {
+                None
+            }
+        }
+
+        let element = Element::RichTextSection {
+            elements: vec![
+                Element::User {
+                    user_id: "U404".to_string(),
+                },
+                Element::Text {
+                    text: " ".to_string(),
+                    style: None,
+                },
+                Element::Channel {
+                    channel_id: "C404".to_string(),
+                },
+            ],
+        };
+
+        let mut resolver = UnknownResolver;
+        let rendered = render(&mut resolver, &element, RenderOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(rendered, "@unknown-user:U404 #unknown-channel:C404");
+    }
     #[tokio::test]
     async fn renders_nested_layouts_with_golden_fixtures() {
         let list_in_quote = Element::RichTextQuote {


### PR DESCRIPTION
### Motivation

- Provide a single, deterministic resolution layer for Slack entities so both rich-text and plain-text paths render mentions/links consistently for IRC consumers.
- Avoid unnecessary API calls by preferring in-memory caches and hydrate them from `users.list` and profile responses.
- Make unknown IDs deterministic and IRC-safe rather than panicking or producing inconsistent fallbacks.

### Description

- Added a new module `src/slack/entity_resolver.rs` which parses Slack entity tokens and provides formatting helpers and deterministic placeholders (e.g. `@unknown-user:U123`).
- Wired the shared resolver into the rich-text renderer (`src/slack/rich_text_renderer.rs`) to render users, channels, teams, usergroups, broadcasts, and links consistently, and changed link rendering to `label (url)` when both are present and distinct or URL-only otherwise.
- Reworked the plain-text fallback parser `parse_usernames` in `src/slack.rs` to use the new parser/formatters and to prefer cached lookups before calling Slack APIs.
- Implemented a cache-aware lookup strategy by adding `user_id_map: HashMap<String,String>` and hydrating it from `users.list` and individual profile fetches.
- Added focused unit tests for the entity resolver and for deterministic unknown mention/link rendering in the rich-text renderer.

### Testing

- Ran formatter and linting with `rustfmt --edition 2021` on the modified files which completed successfully.
- Performed a build smoke-check with `cargo check --lib` which completed successfully in this environment.
- Attempted to run targeted tests (`cargo test entity_resolver::tests::parses_entity_types --lib` and `cargo test rich_text_renderer --lib`) but full test execution was interrupted due to long compilation times in this session; unit tests were added: `entity_resolver::tests::formats_links_with_and_without_label`, `entity_resolver::tests::parses_entity_types`, `rich_text_renderer::renders_link_label_with_url`, and `rich_text_renderer::renders_unknown_mentions_deterministically`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8986973f083318fad65c35093af54)