### PR TITLE
Introduce RemoteActor and consolidate sender identity across transports

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -24,7 +24,7 @@ use serenity::{
 use tokio::sync::{broadcast, Mutex as AsyncMutex};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 
-use crate::{Message, ThreadRef};
+use crate::{Message, RemoteActor, ThreadRef};
 
 const TRANSPORT_NAME: &'static str = "Discord";
 
@@ -433,9 +433,12 @@ impl RealHandler {
                 Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: msg.author.name.clone(),
-                    avatar_url: msg.author.avatar_url(),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        msg.author.id.get().to_string(),
+                        msg.author.name.clone(),
+                        msg.author.avatar_url(),
+                    ),
                     thread,
                     message: Some(content),
                     attachments,
@@ -446,9 +449,12 @@ impl RealHandler {
                 Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: msg.author.name.clone(),
-                    avatar_url: msg.author.avatar_url(),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        msg.author.id.get().to_string(),
+                        msg.author.name.clone(),
+                        msg.author.avatar_url(),
+                    ),
                     thread,
                     message: Some(content),
                     attachments,
@@ -593,9 +599,12 @@ impl RealHandler {
                 Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: author.name.clone(),
-                    avatar_url: author.avatar_url(),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        author.id.get().to_string(),
+                        author.name.clone(),
+                        author.avatar_url(),
+                    ),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -606,9 +615,12 @@ impl RealHandler {
                 Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: author.name.clone(),
-                    avatar_url: author.avatar_url(),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        author.id.get().to_string(),
+                        author.name.clone(),
+                        author.avatar_url(),
+                    ),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -674,19 +686,33 @@ impl RealHandler {
                     return;
                 }
             };
-            let mut username = None;
-            let mut avatar_url = None;
-
-            if let Some(m) = reaction.member {
-                if let Some(nick) = m.nick {
-                    username = Some(nick);
-                }
+            let actor = if let Some(m) = reaction.member {
                 let user = m.user;
-                if username.is_none() {
-                    username = Some(user.name.clone())
+                let display_name = m.nick.unwrap_or_else(|| user.name.clone());
+                RemoteActor::new(
+                    TRANSPORT_NAME,
+                    user.id.get().to_string(),
+                    display_name,
+                    user.avatar_url(),
+                )
+            } else {
+                let user_id = match reaction.user_id {
+                    Some(user_id) => user_id,
+                    None => return,
+                };
+                match user_id.to_user(CacheHttp::http(&ctx)).await {
+                    Ok(user) => RemoteActor::new(
+                        TRANSPORT_NAME,
+                        user.id.get().to_string(),
+                        user.name.clone(),
+                        user.avatar_url(),
+                    ),
+                    Err(e) => {
+                        eprintln!("Failed to fetch reaction user: {}", e);
+                        return;
+                    }
                 }
-                avatar_url = user.avatar_url();
-            }
+            };
 
             let emoji = match reaction.emoji {
                 ReactionType::Custom {
@@ -702,11 +728,9 @@ impl RealHandler {
                 let message = Message::Reaction {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
+                    actor,
                     emoji,
                     remove: false,
-                    username,
-                    avatar_url,
                     thread,
                 };
 
@@ -746,19 +770,33 @@ impl RealHandler {
                     return;
                 }
             };
-            let mut username = None;
-            let mut avatar_url = None;
-
-            if let Some(m) = reaction.member {
-                if let Some(nick) = m.nick {
-                    username = Some(nick);
-                }
+            let actor = if let Some(m) = reaction.member {
                 let user = m.user;
-                if username.is_none() {
-                    username = Some(user.name.clone())
+                let display_name = m.nick.unwrap_or_else(|| user.name.clone());
+                RemoteActor::new(
+                    TRANSPORT_NAME,
+                    user.id.get().to_string(),
+                    display_name,
+                    user.avatar_url(),
+                )
+            } else {
+                let user_id = match reaction.user_id {
+                    Some(user_id) => user_id,
+                    None => return,
+                };
+                match user_id.to_user(CacheHttp::http(&ctx)).await {
+                    Ok(user) => RemoteActor::new(
+                        TRANSPORT_NAME,
+                        user.id.get().to_string(),
+                        user.name.clone(),
+                        user.avatar_url(),
+                    ),
+                    Err(e) => {
+                        eprintln!("Failed to fetch reaction user: {}", e);
+                        return;
+                    }
                 }
-                avatar_url = user.avatar_url();
-            }
+            };
 
             let emoji = match reaction.emoji {
                 ReactionType::Custom {
@@ -774,11 +812,9 @@ impl RealHandler {
                 let message = Message::Reaction {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
+                    actor,
                     emoji,
                     remove: true,
-                    username,
-                    avatar_url,
                     thread,
                 };
 
@@ -1634,9 +1670,7 @@ impl Discord {
         &self,
         channel: ChannelId,
         pipo_id: i64,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         message: Option<String>,
         is_edit: bool,
     ) -> anyhow::Result<()> {
@@ -1676,8 +1710,8 @@ impl Discord {
 
             let mut msg = MessageBuilder::new();
 
-            msg.push_bold(username)
-                .push_line(format!(" [{}]", transport))
+            msg.push_bold(actor.display_name())
+                .push_line(format!(" [{}]", actor.transport()))
                 .push(content.to_string());
 
             channel
@@ -1695,8 +1729,8 @@ impl Discord {
                     eprintln!("Webhook: {:?}", wh);
                     let mut exec = ExecuteWebhook::new()
                         .content(content.to_string())
-                        .username(format!("{} ({})", username.clone(), transport.clone()));
-                    if let Some(url) = avatar_url.clone() {
+                        .username(format!("{} ({})", actor.display_name(), actor.transport()));
+                    if let Some(url) = actor.avatar_url().map(ToOwned::to_owned) {
                         exec = exec.avatar_url(url);
                     }
 
@@ -1709,8 +1743,8 @@ impl Discord {
 
             let mut msg = MessageBuilder::new();
 
-            msg.push_bold(username)
-                .push_line(format!(" [{}]", transport))
+            msg.push_bold(actor.display_name())
+                .push_line(format!(" [{}]", actor.transport()))
                 .push(content.to_string());
 
             self.update_messages_table(pipo_id, channel.say(http, msg.to_string()).await?)
@@ -1794,9 +1828,7 @@ impl Discord {
         &self,
         channel: ChannelId,
         pipo_id: i64,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
@@ -1874,8 +1906,8 @@ impl Discord {
 
             let mut msg = MessageBuilder::new();
 
-            msg.push_bold(username)
-                .push_line(format!(" [{}]", transport))
+            msg.push_bold(actor.display_name())
+                .push_line(format!(" [{}]", actor.transport()))
                 .push(content.to_string());
 
             channel
@@ -1893,8 +1925,8 @@ impl Discord {
                     eprintln!("Webhook: {:?}", wh);
                     let mut exec = ExecuteWebhook::new()
                         .content(content.to_string())
-                        .username(format!("{} ({})", username.clone(), transport.clone()));
-                    if let Some(url) = avatar_url.clone() {
+                        .username(format!("{} ({})", actor.display_name(), actor.transport()));
+                    if let Some(url) = actor.avatar_url().map(ToOwned::to_owned) {
                         exec = exec.avatar_url(url);
                     }
 
@@ -1907,8 +1939,8 @@ impl Discord {
 
             let mut msg = MessageBuilder::new();
 
-            msg.push_bold(username)
-                .push_line(format!(" [{}]", transport))
+            msg.push_bold(actor.display_name())
+                .push_line(format!(" [{}]", actor.transport()))
                 .push(content.to_string());
 
             self.update_messages_table(pipo_id, channel.say(http, msg.to_string()).await?)
@@ -1953,9 +1985,7 @@ impl Discord {
                     Message::Action {
                         sender,
                         pipo_id,
-                        transport,
-                        username,
-                        avatar_url,
+                        actor,
                         thread: _,
                         message,
                         attachments: _,
@@ -1966,9 +1996,7 @@ impl Discord {
                         if let Err(e) = self
                             .handle_action_message(channel_id,
                                        pipo_id,
-                                       transport,
-                                       username,
-                                       avatar_url,
+                                       actor,
                                        message,
                                        is_edit)
                         .await {
@@ -2007,8 +2035,7 @@ impl Discord {
                     },
                     Message::Names {
                         sender: _,
-                        transport: _,
-                        username: _,
+                        actor: _,
                         message: _,
                     } => {
                         continue
@@ -2029,11 +2056,9 @@ impl Discord {
                     Message::Reaction {
                         sender,
                         pipo_id,
-                        transport: _,
+                        actor: _,
                         emoji,
                         remove,
-                        username: _,
-                        avatar_url: _,
                         thread: _,
                     } => {
                         if sender != self.transport_id {
@@ -2053,9 +2078,7 @@ impl Discord {
                     Message::Text {
                         sender,
                         pipo_id,
-                        transport,
-                        username,
-                        avatar_url,
+                        actor,
                         thread,
                         message,
                         attachments,
@@ -2066,9 +2089,7 @@ impl Discord {
                         if let Err(e) = self
                             .handle_text_message(channel_id,
                                      pipo_id,
-                                     transport,
-                                     username,
-                                     avatar_url,
+                                     actor,
                                      thread,
                                      message,
                                      attachments,

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers::BroadcastStream, StreamMap};
 
-use crate::{Attachment, Message, ThreadRef};
+use crate::{Attachment, Message, RemoteActor, ThreadRef};
 use anyhow::anyhow;
 
 const TRANSPORT_NAME: &'static str = "IRC";
@@ -169,9 +169,7 @@ impl IRC {
                         Message::Action {
                         sender,
                         pipo_id,
-                        transport,
-                        username,
-                        avatar_url: _,
+                        actor,
                         thread,
                         message,
                         attachments,
@@ -182,8 +180,7 @@ impl IRC {
                             self.handle_action_message(&client,
                                            &channel,
                                            pipo_id,
-                                           transport,
-                                           username,
+                                           actor,
                                            thread,
                                            message,
                                            attachments,
@@ -217,15 +214,11 @@ impl IRC {
                         },
                         Message::Names {
                         sender,
-                        transport: _,
-                        username,
+                        actor,
                         message,
                         } => {
                         if sender != self.transport_id {
-                            self.handle_names_message(&client,
-                                          &channel,
-                                          username,
-                                          message);
+                            self.handle_names_message(&client, &channel, actor, message);
                         }
                         },
                         Message::Pin {
@@ -238,11 +231,9 @@ impl IRC {
                         Message::Reaction {
                         sender: _,
                         pipo_id: _,
-                        transport: _,
+                        actor: _,
                         emoji: _,
                         remove: _,
-                        username: _,
-                        avatar_url: _,
                         thread: _,
                         } => {
                         continue
@@ -250,9 +241,7 @@ impl IRC {
                         Message::Text {
                         sender,
                         pipo_id,
-                        transport,
-                        username,
-                        avatar_url: _,
+                        actor,
                         thread,
                         message,
                         attachments,
@@ -263,8 +252,7 @@ impl IRC {
                             self.handle_text_message(&client,
                                          &channel,
                                          pipo_id,
-                                         transport,
-                                         username,
+                                         actor,
                                          thread,
                                          message,
                                          attachments,
@@ -326,8 +314,7 @@ impl IRC {
         client: &Client,
         channel: &str,
         pipo_id: i64,
-        transport: String,
-        username: String,
+        actor: RemoteActor,
         thread: Option<crate::ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
@@ -352,9 +339,8 @@ impl IRC {
 
             if let Some(prefix) = thread_presentation.plaintext_prefix.as_ref() {
                 let prefix_message = format!(
-                    "\x01ACTION \x02* \x02{}!\x02{}\x02 {}\x01",
-                    &transport[..1].to_uppercase(),
-                    username,
+                    "\x01ACTION \x02* \x02{}\x02 {}\x01",
+                    self.irc_nick_from_actor(&actor),
                     prefix
                 );
 
@@ -384,16 +370,14 @@ impl IRC {
                     is_edit = false;
 
                     format!(
-                        "\x01ACTION \x02* \x02{}!\x02{}\x02 {}*\x01",
-                        &transport[..1].to_uppercase(),
-                        username,
+                        "\x01ACTION \x02* \x02{}\x02 {}*\x01",
+                        self.irc_nick_from_actor(&actor),
                         msg
                     )
                 } else {
                     format!(
-                        "\x01ACTION \x02* \x02{}!\x02{}\x02 {}\x01",
-                        &transport[..1].to_uppercase(),
-                        username,
+                        "\x01ACTION \x02* \x02{}\x02 {}\x01",
+                        self.irc_nick_from_actor(&actor),
                         msg
                     )
                 };
@@ -443,7 +427,7 @@ impl IRC {
         &self,
         client: &Client,
         channel: &str,
-        username: String,
+        actor: RemoteActor,
         message: Option<String>,
     ) {
         if message == Some("/names".to_string()) {
@@ -454,8 +438,7 @@ impl IRC {
                     .collect();
                 let message = Message::Names {
                     sender: self.transport_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: username.to_string(),
+                    actor,
                     message: Some(serde_json::json!(users).to_string()),
                 };
 
@@ -474,8 +457,7 @@ impl IRC {
         client: &Client,
         channel: &str,
         pipo_id: i64,
-        transport: String,
-        username: String,
+        actor: RemoteActor,
         thread: Option<crate::ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
@@ -500,9 +482,8 @@ impl IRC {
 
             if let Some(prefix) = thread_presentation.plaintext_prefix.as_ref() {
                 let prefix_message = format!(
-                    "\x01ACTION <{}!\x02{}\x02> {}\x01",
-                    &transport[..1].to_uppercase(),
-                    username,
+                    "\x01ACTION <{}> {}\x01",
+                    self.irc_nick_from_actor(&actor),
                     prefix
                 );
 
@@ -532,16 +513,14 @@ impl IRC {
                     is_edit = false;
 
                     format!(
-                        "\x01ACTION <{}!\x02{}\x02> \x02EDIT:\x02 {}\x01",
-                        &transport[..1].to_uppercase(),
-                        username,
+                        "\x01ACTION <{}> \x02EDIT:\x02 {}\x01",
+                        self.irc_nick_from_actor(&actor),
                         msg
                     )
                 } else {
                     format!(
-                        "\x01ACTION <{}!\x02{}\x02> {}\x01",
-                        &transport[..1].to_uppercase(),
-                        username,
+                        "\x01ACTION <{}> {}\x01",
+                        self.irc_nick_from_actor(&actor),
                         msg
                     )
                 };
@@ -1007,7 +986,11 @@ impl IRC {
                     .into_iter()
                     .take(THREAD_LIST_LIMIT)
                     .map(|(token, entry)| {
-                        format!("{} ({})", token, self.thread_root_summary(&entry.thread_ref))
+                        format!(
+                            "{} ({})",
+                            token,
+                            self.thread_root_summary(&entry.thread_ref)
+                        )
                     })
                     .collect::<Vec<_>>()
                     .join(" | ")
@@ -1157,6 +1140,39 @@ impl IRC {
         format!("{}…", truncated)
     }
 
+    fn irc_nick_from_actor(&self, actor: &RemoteActor) -> String {
+        let transport_prefix = actor
+            .transport()
+            .chars()
+            .next()
+            .map(|c| c.to_ascii_uppercase())
+            .unwrap_or('U');
+        let display = actor
+            .display_name()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+            .take(20)
+            .collect::<String>();
+        let stable_suffix = actor
+            .remote_id()
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric())
+            .take(8)
+            .collect::<String>();
+        let display = if display.is_empty() {
+            "user"
+        } else {
+            display.as_str()
+        };
+        let stable_suffix = if stable_suffix.is_empty() {
+            "anon"
+        } else {
+            stable_suffix.as_str()
+        };
+
+        format!("{}{}-{}", transport_prefix, display, stable_suffix)
+    }
+
     fn parse_message_id_tag(message: &IrcMessage) -> Option<String> {
         let tags = message.tags.as_ref()?;
 
@@ -1236,9 +1252,12 @@ impl IRC {
                 let message = Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: nickname.clone(),
-                    avatar_url: Some(avatar_url),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        nickname.clone(),
+                        nickname.clone(),
+                        Some(avatar_url),
+                    ),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -1268,9 +1287,12 @@ impl IRC {
                 let message = Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: nickname.clone(),
-                    avatar_url: Some(avatar_url),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        nickname.clone(),
+                        nickname.clone(),
+                        Some(avatar_url),
+                    ),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -1460,9 +1482,12 @@ impl IRC {
                 let message = Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: nickname.clone(),
-                    avatar_url: Some(avatar_url),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        nickname.clone(),
+                        nickname.clone(),
+                        Some(avatar_url),
+                    ),
                     thread: None,
                     message: Some(message.to_string()),
                     attachments: None,
@@ -1477,9 +1502,12 @@ impl IRC {
                 let message = Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
-                    username: nickname.clone(),
-                    avatar_url: Some(avatar_url),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        nickname.clone(),
+                        nickname.clone(),
+                        Some(avatar_url),
+                    ),
                     thread: None,
                     message: Some(format!("```{}```", message.to_string())),
                     attachments: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    env, fmt, os,
+    env, fmt,
     sync::{Arc, Mutex},
 };
 
@@ -20,21 +20,61 @@ mod rachni;
 pub mod slack;
 
 use crate::discord::Discord;
-use crate::irc::{IRC, ThreadContextRepeat, ThreadFallbackStyle, ThreadPresentationMode};
+use crate::irc::{ThreadContextRepeat, ThreadFallbackStyle, ThreadPresentationMode, IRC};
 use crate::mumble::Mumble;
 use crate::rachni::Rachni;
 use crate::slack::Slack;
 
 pub use crate::slack::objects;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RemoteActor {
+    transport: String,
+    remote_id: String,
+    display_name: String,
+    avatar_url: Option<String>,
+    presence_identity_key: Option<String>,
+}
+
+impl RemoteActor {
+    fn new(
+        transport: impl Into<String>,
+        remote_id: impl Into<String>,
+        display_name: impl Into<String>,
+        avatar_url: Option<String>,
+    ) -> Self {
+        Self {
+            transport: transport.into(),
+            remote_id: remote_id.into(),
+            display_name: display_name.into(),
+            avatar_url,
+            presence_identity_key: None,
+        }
+    }
+
+    fn transport(&self) -> &str {
+        &self.transport
+    }
+
+    fn remote_id(&self) -> &str {
+        &self.remote_id
+    }
+
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn avatar_url(&self) -> Option<&str> {
+        self.avatar_url.as_deref()
+    }
+}
+
 #[derive(Clone, Debug)]
 enum Message {
     Action {
         sender: usize,
         pipo_id: i64,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
@@ -56,8 +96,7 @@ enum Message {
     },
     Names {
         sender: usize,
-        transport: String,
-        username: String,
+        actor: RemoteActor,
         message: Option<String>,
     },
     Pin {
@@ -68,19 +107,15 @@ enum Message {
     Reaction {
         sender: usize,
         pipo_id: i64,
-        transport: String,
+        actor: RemoteActor,
         emoji: String,
         remove: bool,
-        username: Option<String>,
-        avatar_url: Option<String>,
         thread: Option<ThreadRef>,
     },
     Text {
         sender: usize,
         pipo_id: i64,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
@@ -129,9 +164,7 @@ impl fmt::Display for Message {
             Message::Action {
                 sender: _,
                 pipo_id: _,
-                transport: _,
-                username: _,
-                avatar_url: _,
+                actor: _,
                 thread: _,
                 message,
                 attachments: _,
@@ -159,8 +192,7 @@ impl fmt::Display for Message {
             } => write!(f, "Delete message"),
             Message::Names {
                 sender: _,
-                transport: _,
-                username: _,
+                actor: _,
                 message,
             } => match message {
                 Some(message) => write!(f, "{}", message),
@@ -174,19 +206,15 @@ impl fmt::Display for Message {
             Message::Reaction {
                 sender: _,
                 pipo_id: _,
-                transport: _,
+                actor: _,
                 emoji,
                 remove: _,
-                username: _,
-                avatar_url: _,
                 thread: _,
             } => write!(f, ":{}:", emoji),
             Message::Text {
                 sender: _,
                 pipo_id: _,
-                transport: _,
-                username: _,
-                avatar_url: _,
+                actor: _,
                 thread: _,
                 message,
                 attachments: _,

--- a/src/mumble.rs
+++ b/src/mumble.rs
@@ -29,7 +29,7 @@ use tokio_rustls::{
 use tokio_stream::{wrappers::BroadcastStream, StreamMap};
 use webpki_roots;
 
-use crate::{Attachment, Message};
+use crate::{Attachment, Message, RemoteActor};
 
 mod cert_verifier;
 mod protocol;
@@ -541,9 +541,12 @@ impl Mumble {
                     let message = Message::Text {
                         sender: self.transport_id,
                         pipo_id,
-                        transport: TRANSPORT_NAME.to_string(),
-                        username,
-                        avatar_url: None,
+                        actor: RemoteActor::new(
+                            TRANSPORT_NAME,
+                            message.actor().to_string(),
+                            username,
+                            None,
+                        ),
                         thread: None,
                         message: Some(
                             html_escape::decode_html_entities(message.message()).to_string(),
@@ -579,8 +582,7 @@ impl Mumble {
         match message {
             Message::Action {
                 sender,
-                transport,
-                username,
+                actor,
                 message,
                 attachments,
                 is_edit,
@@ -589,8 +591,8 @@ impl Mumble {
                 if sender != self.transport_id {
                     self.handle_pipo_action_message(
                         &channel,
-                        &transport,
-                        &username,
+                        actor.transport(),
+                        actor.display_name(),
                         message.as_deref(),
                         attachments,
                         is_edit,
@@ -610,10 +612,9 @@ impl Mumble {
                 Ok(())
             }
             Message::Names {
-                sender,
-                transport: _,
-                username,
-                message,
+                actor: _,
+                message: _,
+                sender: _,
             } => {
                 // TODO
                 Ok(())
@@ -628,8 +629,7 @@ impl Mumble {
             }
             Message::Text {
                 sender,
-                transport,
-                username,
+                actor,
                 message,
                 attachments,
                 is_edit,
@@ -638,8 +638,8 @@ impl Mumble {
                 if sender != self.transport_id {
                     self.handle_pipo_text_message(
                         &channel,
-                        &transport,
-                        &username,
+                        actor.transport(),
+                        actor.display_name(),
                         message.as_deref(),
                         attachments,
                         is_edit,

--- a/src/rachni.rs
+++ b/src/rachni.rs
@@ -13,7 +13,7 @@ use tokio::{
     time::{self, Duration},
 };
 
-use crate::Message;
+use crate::{Message, RemoteActor};
 
 const TRANSPORT_NAME: &'static str = "Rachni";
 
@@ -128,9 +128,12 @@ impl Rachni {
         let message = Message::Action {
             sender: self.transport_id,
             pipo_id,
-            transport: TRANSPORT_NAME.to_string(),
-            username: username.to_string(),
-            avatar_url,
+            actor: RemoteActor::new(
+                TRANSPORT_NAME,
+                username.to_string(),
+                username.to_string(),
+                avatar_url,
+            ),
             thread: None,
             message: Some(message.to_string()),
             attachments: None,

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -23,7 +23,7 @@ use tokio::{net::TcpStream, sync::broadcast};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 use tokio_tungstenite::*;
 
-use crate::{Message, ThreadRef};
+use crate::{Message, RemoteActor, ThreadRef};
 
 pub mod objects;
 use objects::{Message as SlackMessage, *};
@@ -154,9 +154,7 @@ impl Slack {
                     Message::Action {
                     sender,
                     pipo_id,
-                    transport,
-                    username,
-                    avatar_url,
+                    actor,
                     thread,
                     message,
                     attachments,
@@ -167,9 +165,7 @@ impl Slack {
                         if let Err(e)
                         = self.post_action_message(pipo_id,
                                        &channel,
-                                       transport,
-                                       username,
-                                       avatar_url,
+                                       actor,
                                        thread,
                                        message,
                                        attachments,
@@ -217,15 +213,13 @@ impl Slack {
                     },
                     Message::Names {
                     sender,
-                    transport,
-                    username,
+                    actor,
                     message,
                     } => {
                     if sender != self.transport_id {
                         if let Err(e)
                         = self.post_names_message(&channel,
-                                      transport,
-                                      username,
+                                      actor,
                                       message)
                         .await {
                             eprintln!("Failed to post message:\
@@ -258,21 +252,17 @@ impl Slack {
                     Message::Reaction {
                     sender,
                     pipo_id,
-                    transport,
+                    actor,
                     emoji,
                     remove,
-                    username,
-                    avatar_url,
                     thread
                     } => if sender != self.transport_id {
                     if !remove {
                         if let Err(e)
                         = self.add_reaction(pipo_id,
                                     &channel,
-                                    transport,
+                                    actor,
                                     emoji,
-                                    username,
-                                    avatar_url,
                                     thread).await {
                             eprintln!("Failed to add \
                                    reaction: {}", e)
@@ -282,10 +272,8 @@ impl Slack {
                         if let Err(e)
                         = self.remove_reaction(pipo_id,
                                        &channel,
-                                       transport,
+                                       actor,
                                        emoji,
-                                       username,
-                                       avatar_url,
                                        thread)
                         .await {
                             eprintln!("Failed to remove \
@@ -296,9 +284,7 @@ impl Slack {
                     Message::Text {
                     sender,
                     pipo_id,
-                    transport,
-                    username,
-                    avatar_url,
+                    actor,
                     thread,
                     message,
                     attachments,
@@ -309,9 +295,7 @@ impl Slack {
                         if let Err(e)
                         = self.post_text_message(pipo_id,
                                      &channel,
-                                     transport,
-                                     username,
-                                     avatar_url,
+                                     actor,
                                      thread,
                                      message,
                                      attachments,
@@ -434,10 +418,8 @@ impl Slack {
         &mut self,
         pipo_id: i64,
         channel: &str,
-        _transport: String,
+        _actor: RemoteActor,
         emoji: String,
-        _username: Option<String>,
-        _avatar_url: Option<String>,
         _thread: Option<ThreadRef>,
     ) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
@@ -624,9 +606,7 @@ impl Slack {
         &mut self,
         pipo_id: i64,
         channel: &str,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
@@ -640,31 +620,12 @@ impl Slack {
 
         if is_edit {
             if let Some(ts) = self.select_slackid_from_messages(pipo_id).await? {
-                return self
-                    .update(
-                        ts,
-                        channel,
-                        transport,
-                        username,
-                        avatar_url,
-                        message,
-                        attachments,
-                    )
-                    .await;
+                return self.update(ts, channel, actor, message, attachments).await;
             }
         }
 
         return self
-            .post_message(
-                pipo_id,
-                channel,
-                transport,
-                username,
-                avatar_url,
-                thread_ts,
-                message,
-                attachments,
-            )
+            .post_message(pipo_id, channel, actor, thread_ts, message, attachments)
             .await;
     }
 
@@ -684,8 +645,7 @@ impl Slack {
     async fn post_names_message(
         &mut self,
         channel: &str,
-        transport: String,
-        username: String,
+        actor: RemoteActor,
         message: Option<String>,
     ) -> anyhow::Result<()> {
         let message = message.unwrap();
@@ -693,8 +653,7 @@ impl Slack {
             let users: Vec<String> = self.users.iter().map(|(user, _)| user.clone()).collect();
             let message = Message::Names {
                 sender: self.transport_id,
-                transport: TRANSPORT_NAME.to_string(),
-                username: username,
+                actor,
                 message: Some(serde_json::json!(users).to_string()),
             };
 
@@ -712,14 +671,15 @@ impl Slack {
         } else {
             let mut headers = HeaderMap::new();
             let json: Value = serde_json::from_str(&message)?;
-            let username = match self.users.get(&username) {
+            let user_id = actor.remote_id();
+            let username = match self.users.get(user_id) {
                 Some(user) => match &user.id {
                     Some(s) => s,
                     None => {
                         return Err(anyhow!(
                             "Couldn't find user id for \
                         user: {}",
-                            username
+                            user_id
                         ))
                     }
                 },
@@ -727,7 +687,7 @@ impl Slack {
                     return Err(anyhow!(
                         "Couldn't find user {} in local \
                         cache",
-                        username
+                        user_id
                     ))
                 }
             };
@@ -764,7 +724,7 @@ impl Slack {
                     Element::RichTextSection {
                         elements: vec![
                             Element::Text {
-                                text: transport,
+                                text: actor.transport().to_string(),
                                 style: Some(Style {
                                     bold: Some(true),
                                     code: None,
@@ -808,9 +768,7 @@ impl Slack {
         &mut self,
         pipo_id: i64,
         channel: &str,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
@@ -826,31 +784,12 @@ impl Slack {
 
         if is_edit {
             if let Some(ts) = self.select_slackid_from_messages(pipo_id).await? {
-                return self
-                    .update(
-                        ts,
-                        channel,
-                        transport,
-                        username,
-                        avatar_url,
-                        message,
-                        attachments,
-                    )
-                    .await;
+                return self.update(ts, channel, actor, message, attachments).await;
             }
         }
 
         return self
-            .post_message(
-                pipo_id,
-                channel,
-                transport,
-                username,
-                avatar_url,
-                thread_ts,
-                message,
-                attachments,
-            )
+            .post_message(pipo_id, channel, actor, thread_ts, message, attachments)
             .await;
     }
 
@@ -858,9 +797,7 @@ impl Slack {
         &mut self,
         pipo_id: i64,
         channel: &str,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         thread_ts: Option<String>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
@@ -871,8 +808,8 @@ impl Slack {
             None => return Err(anyhow!("Could not find id for channel {}", channel)),
         };
         let message = message.map(|s| self.insert_user_names(s));
-        let icon_url = Slack::get_avatar_url(avatar_url);
-        let username = format!("{} ({})", &username, transport);
+        let icon_url = Slack::get_avatar_url(actor.avatar_url().map(ToOwned::to_owned));
+        let username = format!("{} ({})", actor.display_name(), actor.transport());
         let attachments = match attachments {
             Some(a) => Some(self.prepare_attachments_for_slack(&channel, a).await),
             None => None,
@@ -927,10 +864,8 @@ impl Slack {
         &mut self,
         pipo_id: i64,
         channel: &str,
-        _transport: String,
+        _actor: RemoteActor,
         emoji: String,
-        _username: Option<String>,
-        _avatar_url: Option<String>,
         _thread: Option<ThreadRef>,
     ) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
@@ -980,9 +915,7 @@ impl Slack {
         &mut self,
         ts: String,
         channel: &str,
-        transport: String,
-        username: String,
-        avatar_url: Option<String>,
+        actor: RemoteActor,
         message: Option<String>,
         _attachments: Option<Vec<crate::Attachment>>,
     ) -> anyhow::Result<()> {
@@ -992,8 +925,8 @@ impl Slack {
             None => return Err(anyhow!("Could not find id for channel {}", channel)),
         };
         let message = message.map(|s| self.insert_user_names(s));
-        let icon_url = Slack::get_avatar_url(avatar_url);
-        let username = format!("{} ({})", &username, transport);
+        let icon_url = Slack::get_avatar_url(actor.avatar_url().map(ToOwned::to_owned));
+        let username = format!("{} ({})", actor.display_name(), actor.transport());
         let body = serde_json::json!({
         "channel":channel,
         "ts":ts,
@@ -1310,8 +1243,12 @@ impl Slack {
                 if accepts_response {
                     let message = Message::Names {
                         sender: self.transport_id,
-                        transport: TRANSPORT_NAME.to_string(),
-                        username: payload.user_name,
+                        actor: RemoteActor::new(
+                            TRANSPORT_NAME,
+                            payload.user_id,
+                            payload.user_name,
+                            None,
+                        ),
                         message: Some("/names".to_string()),
                     };
                     let channel = &format!("#{}", payload.channel_name);
@@ -1786,12 +1723,14 @@ impl Slack {
             .await?;
         let username = Slack::get_username(&user)?;
         let avatar_url = Slack::get_avatar_url_for_user(&user)?;
+        let user_id = user
+            .id
+            .clone()
+            .ok_or_else(|| anyhow!("No user ID in user info response."))?;
         let message = Message::Action {
             sender: self.transport_id,
             pipo_id,
-            transport: TRANSPORT_NAME.to_string(),
-            username,
-            avatar_url,
+            actor: RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url),
             thread: None,
             message: message,
             attachments: None,
@@ -2090,6 +2029,10 @@ impl Slack {
             )
             .await?;
         let avatar_url = Slack::get_avatar_url_for_user(&user)?;
+        let user_id = user
+            .id
+            .clone()
+            .ok_or_else(|| anyhow!("No user ID in user info response."))?;
         let attachments = match attachments {
             Some(attachments) => Some(self.handle_attachments(attachments).await),
             None => None,
@@ -2107,9 +2050,7 @@ impl Slack {
             let message = Message::Text {
                 pipo_id,
                 sender: self.transport_id,
-                transport: TRANSPORT_NAME.to_string(),
-                username,
-                avatar_url,
+                actor: RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url),
                 thread,
                 message: message,
                 attachments,
@@ -2255,11 +2196,16 @@ impl Slack {
                 let message = Message::Reaction {
                     sender: self.transport_id,
                     pipo_id,
-                    transport: TRANSPORT_NAME.to_string(),
+                    actor: RemoteActor::new(
+                        TRANSPORT_NAME,
+                        user.clone()
+                            .ok_or_else(|| anyhow!("Reaction event missing user id"))?,
+                        user.clone()
+                            .ok_or_else(|| anyhow!("Reaction event missing user id"))?,
+                        None,
+                    ),
                     emoji: reaction,
                     remove,
-                    username: user,
-                    avatar_url: None,
                     thread: None,
                 };
 


### PR DESCRIPTION
### Motivation

- Unify how remote user identity (transport, id, display name, avatar) is represented and propagated through the system instead of passing separate `transport`, `username`, and `avatar_url` fields.

### Description

- Add a new `RemoteActor` struct with `transport`, `remote_id`, `display_name`, `avatar_url` and accessor methods, and use `RemoteActor::new(...)` to construct instances.
- Replace per-message fields `transport`, `username`, and `avatar_url` with a single `actor: RemoteActor` across the `Message` enum and all transports (`discord`, `irc`, `slack`, `mumble`, `rachni`).
- Update all handlers and functions to accept and use `RemoteActor` (including webhook username/avatar usage and reaction handling), and add `irc_nick_from_actor` helper to generate an IRC-friendly nick from an actor.
- Adjust various codepaths to fetch user info when necessary (e.g. reactions) and to format/display actor information consistently (e.g. `actor.display_name()` and `actor.transport()`).

### Testing

- Ran `cargo build` to ensure the codebase compiles after API/signature changes, and it completed successfully.
- Ran the unit test suite with `cargo test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5917ae708331b469f78a22f860cd)