### PR TITLE
Persist remote actor identities and IRC presence state

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -24,7 +24,7 @@ use serenity::{
 use tokio::sync::{broadcast, Mutex as AsyncMutex};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 
-use crate::{Message, RemoteActor, ThreadRef};
+use crate::{upsert_remote_actor, Message, RemoteActor, ThreadRef};
 
 const TRANSPORT_NAME: &'static str = "Discord";
 
@@ -424,6 +424,15 @@ impl RealHandler {
                 _ => Some(attachments),
             };
 
+            let actor = RemoteActor::new(
+                TRANSPORT_NAME,
+                msg.author.id.get().to_string(),
+                msg.author.name.clone(),
+                msg.author.avatar_url(),
+            );
+            if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+                eprintln!("Failed to upsert Discord actor: {}", e);
+            }
             let message = if let Some(captures) = RE.captures(&content) {
                 content = match captures.get(1) {
                     Some(c) => c.as_str(),
@@ -433,12 +442,7 @@ impl RealHandler {
                 Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    actor: RemoteActor::new(
-                        TRANSPORT_NAME,
-                        msg.author.id.get().to_string(),
-                        msg.author.name.clone(),
-                        msg.author.avatar_url(),
-                    ),
+                    actor: actor.clone(),
                     thread,
                     message: Some(content),
                     attachments,
@@ -449,12 +453,7 @@ impl RealHandler {
                 Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    actor: RemoteActor::new(
-                        TRANSPORT_NAME,
-                        msg.author.id.get().to_string(),
-                        msg.author.name.clone(),
-                        msg.author.avatar_url(),
-                    ),
+                    actor: actor.clone(),
                     thread,
                     message: Some(content),
                     attachments,
@@ -530,7 +529,7 @@ impl RealHandler {
         // authentication error, or lack of permissions to post in the
         // channel, so log to stdout when some error happens, with a
         // description of it.
-        let author = match msg.author {
+        let author = match msg.author.clone() {
             Some(s) => s,
             None => return,
         };
@@ -590,6 +589,19 @@ impl RealHandler {
                 }
             }
 
+            let author = match msg.author {
+                Some(author) => author,
+                None => return,
+            };
+            let actor = RemoteActor::new(
+                TRANSPORT_NAME,
+                author.id.get().to_string(),
+                author.name.clone(),
+                author.avatar_url(),
+            );
+            if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+                eprintln!("Failed to upsert Discord actor: {}", e);
+            }
             let message = if let Some(captures) = RE.captures(&content) {
                 content = match captures.get(1) {
                     Some(c) => c.as_str(),
@@ -599,12 +611,7 @@ impl RealHandler {
                 Message::Action {
                     sender: self.transport_id,
                     pipo_id,
-                    actor: RemoteActor::new(
-                        TRANSPORT_NAME,
-                        author.id.get().to_string(),
-                        author.name.clone(),
-                        author.avatar_url(),
-                    ),
+                    actor: actor.clone(),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -615,12 +622,7 @@ impl RealHandler {
                 Message::Text {
                     sender: self.transport_id,
                     pipo_id,
-                    actor: RemoteActor::new(
-                        TRANSPORT_NAME,
-                        author.id.get().to_string(),
-                        author.name.clone(),
-                        author.avatar_url(),
-                    ),
+                    actor: actor.clone(),
                     thread,
                     message: Some(content),
                     attachments: None,
@@ -714,6 +716,10 @@ impl RealHandler {
                 }
             };
 
+            if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+                eprintln!("Failed to upsert Discord actor: {}", e);
+            }
+
             let emoji = match reaction.emoji {
                 ReactionType::Custom {
                     animated: _,
@@ -797,6 +803,10 @@ impl RealHandler {
                     }
                 }
             };
+
+            if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+                eprintln!("Failed to upsert Discord actor: {}", e);
+            }
 
             let emoji = match reaction.emoji {
                 ReactionType::Custom {

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -17,7 +17,10 @@ use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc};
 use tokio_stream::{wrappers::BroadcastStream, StreamMap};
 
-use crate::{Attachment, Message, RemoteActor, ThreadRef};
+use crate::{
+    load_irc_presence, upsert_irc_presence, upsert_remote_actor, Attachment, Message, RemoteActor,
+    ThreadRef,
+};
 
 const TRANSPORT_NAME: &str = "IRC";
 const DEFAULT_THREAD_EXCERPT_LEN: usize = 120;
@@ -109,6 +112,7 @@ struct SessionManagerInner {
     transport_id: usize,
     presence_prefix: String,
     capabilities: Arc<Mutex<IrcCapabilityState>>,
+    pool: Pool,
     state: Mutex<HashMap<String, ActorSessionHandle>>,
 }
 
@@ -124,6 +128,7 @@ impl SessionManager {
         transport_id: usize,
         capabilities: Arc<Mutex<IrcCapabilityState>>,
         presence_prefix: String,
+        pool: Pool,
     ) -> Self {
         Self {
             inner: Arc::new(SessionManagerInner {
@@ -131,6 +136,7 @@ impl SessionManager {
                 transport_id,
                 presence_prefix,
                 capabilities,
+                pool,
                 state: Mutex::new(HashMap::new()),
             }),
         }
@@ -144,11 +150,11 @@ impl SessionManager {
     ) -> anyhow::Result<()> {
         let actor_key = format!("{}:{}", actor.transport(), actor.remote_id());
         let channel = outbound.channel.clone();
-        let (sender, nick) = {
+        let initial_nick = self.nick_from_actor(actor, 0);
+        let sender = {
             let mut state = self.inner.state.lock().unwrap();
             let handle = state.entry(actor_key.clone()).or_insert_with(|| {
-                let nick = self.nick_from_actor(actor, 0);
-                let sender = self.spawn_session_task(actor.clone(), nick.clone());
+                let sender = self.spawn_session_task(actor.clone(), initial_nick.clone());
                 ActorSessionHandle {
                     sender,
                     channels: HashMap::new(),
@@ -157,7 +163,7 @@ impl SessionManager {
             });
             *handle.channels.entry(channel).or_insert(0) = 1;
             handle.last_used = Instant::now();
-            (handle.sender.clone(), self.nick_from_actor(actor, 0))
+            handle.sender.clone()
         };
 
         if let Err(err) = sender.send(SessionCommand { outbound, payload }).await {
@@ -165,7 +171,7 @@ impl SessionManager {
             state.remove(&actor_key);
             return Err(anyhow!(
                 "failed to send IRC session command for {}: {}",
-                nick,
+                initial_nick,
                 err
             ));
         }
@@ -181,8 +187,26 @@ impl SessionManager {
         let (tx, mut rx) = mpsc::channel::<SessionCommand>(32);
         let manager = self.clone();
         tokio::spawn(async move {
-            let mut nick_attempt = 0usize;
-            let mut current_nick = initial_nick;
+            let (mut nick_attempt, mut current_nick) =
+                match load_irc_presence(&manager.inner.pool, &actor).await {
+                    Ok(Some((preferred_nick, last_successful_nick, collision_suffix))) => {
+                        let nick_attempt = collision_suffix.max(0) as usize;
+                        let nick = last_successful_nick
+                            .or(preferred_nick)
+                            .unwrap_or(initial_nick.clone());
+                        (nick_attempt, nick)
+                    }
+                    Ok(None) | Err(_) => (0usize, initial_nick),
+                };
+            let _ = upsert_irc_presence(
+                &manager.inner.pool,
+                &actor,
+                Some(&current_nick),
+                None,
+                nick_attempt as i64,
+                false,
+            )
+            .await;
             let mut connected: Option<(Client, irc::client::ClientStream)> = None;
             let born_at = Instant::now();
             let mut idle_deadline = tokio::time::Instant::now() + ACTOR_SESSION_IDLE_TIMEOUT;
@@ -193,11 +217,15 @@ impl SessionManager {
                         idle_deadline = tokio::time::Instant::now() + ACTOR_SESSION_IDLE_TIMEOUT;
                         if connected.is_none() {
                             match manager.connect_actor_client(&current_nick).await {
-                                Ok(client_stream) => connected = Some(client_stream),
+                                Ok(client_stream) => {
+                                    let _ = upsert_irc_presence(&manager.inner.pool, &actor, Some(&current_nick), Some(&current_nick), nick_attempt as i64, true).await;
+                                    connected = Some(client_stream)
+                                },
                                 Err(err) => {
                                     eprintln!("Failed to connect actor IRC session {}: {:#}", current_nick, err);
                                     nick_attempt += 1;
                                     current_nick = manager.nick_from_actor(&actor, nick_attempt);
+                                    let _ = upsert_irc_presence(&manager.inner.pool, &actor, Some(&current_nick), None, nick_attempt as i64, false).await;
                                     continue;
                                 }
                             }
@@ -214,6 +242,7 @@ impl SessionManager {
                             connected = None;
                             nick_attempt += 1;
                             current_nick = manager.nick_from_actor(&actor, nick_attempt);
+                            let _ = upsert_irc_presence(&manager.inner.pool, &actor, Some(&current_nick), None, nick_attempt as i64, false).await;
                         }
                     }
                     _ = tokio::time::sleep_until(idle_deadline) => {
@@ -237,6 +266,7 @@ impl SessionManager {
                                     connected = None;
                                     nick_attempt += 1;
                                     current_nick = manager.nick_from_actor(&actor, nick_attempt);
+                                    let _ = upsert_irc_presence(&manager.inner.pool, &actor, Some(&current_nick), None, nick_attempt as i64, false).await;
                                 }
                             }
                             Some(Err(err)) => {
@@ -471,6 +501,7 @@ impl IRC {
                     .take(2)
                     .collect::<String>()
                     .to_ascii_uppercase(),
+                pool.clone(),
             ))
         } else {
             None
@@ -1373,16 +1404,29 @@ impl IRC {
                 return Ok(());
             }
         }
+        let actor = RemoteActor::new(
+            TRANSPORT_NAME,
+            nickname.clone(),
+            nickname.clone(),
+            Some(avatar_url),
+        );
+        if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+            eprintln!("Failed to upsert IRC actor: {}", e);
+        }
+        let _ = upsert_irc_presence(
+            &self.pool,
+            &actor,
+            Some(&self.irc_nick_from_actor(&actor)),
+            None,
+            0,
+            true,
+        )
+        .await;
         let outbound = if RE.is_match(&message) {
             Message::Action {
                 sender: self.transport_id,
                 pipo_id,
-                actor: RemoteActor::new(
-                    TRANSPORT_NAME,
-                    nickname.clone(),
-                    nickname.clone(),
-                    Some(avatar_url),
-                ),
+                actor: actor.clone(),
                 thread,
                 message: Some(content),
                 attachments: None,
@@ -1393,12 +1437,7 @@ impl IRC {
             Message::Text {
                 sender: self.transport_id,
                 pipo_id,
-                actor: RemoteActor::new(
-                    TRANSPORT_NAME,
-                    nickname.clone(),
-                    nickname.clone(),
-                    Some(avatar_url),
-                ),
+                actor,
                 thread,
                 message: Some(content),
                 attachments: None,
@@ -1554,16 +1593,29 @@ impl IRC {
                 .await?;
         }
         let avatar_url = self.get_avatar_url(&nickname).await;
+        let actor = RemoteActor::new(
+            TRANSPORT_NAME,
+            nickname.clone(),
+            nickname.clone(),
+            Some(avatar_url),
+        );
+        if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+            eprintln!("Failed to upsert IRC actor: {}", e);
+        }
+        let _ = upsert_irc_presence(
+            &self.pool,
+            &actor,
+            Some(&self.irc_nick_from_actor(&actor)),
+            None,
+            0,
+            true,
+        )
+        .await;
         let outbound = if let Some(message) = RE.captures(&message) {
             Message::Action {
                 sender: self.transport_id,
                 pipo_id,
-                actor: RemoteActor::new(
-                    TRANSPORT_NAME,
-                    nickname.clone(),
-                    nickname.clone(),
-                    Some(avatar_url),
-                ),
+                actor: actor.clone(),
                 thread: None,
                 message: Some(format!("```{}```", message.get(1).unwrap().as_str())),
                 attachments: None,
@@ -1574,12 +1626,7 @@ impl IRC {
             Message::Text {
                 sender: self.transport_id,
                 pipo_id,
-                actor: RemoteActor::new(
-                    TRANSPORT_NAME,
-                    nickname.clone(),
-                    nickname.clone(),
-                    Some(avatar_url),
-                ),
+                actor,
                 thread: None,
                 message: Some(format!("```{}```", message)),
                 attachments: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use deadpool_sqlite::Pool;
 use deadpool_sqlite::{Config, Runtime};
 use regex::bytes::Regex;
 use rusqlite::Error::QueryReturnedNoRows;
@@ -69,6 +70,91 @@ impl RemoteActor {
     fn avatar_url(&self) -> Option<&str> {
         self.avatar_url.as_deref()
     }
+}
+
+pub(crate) async fn upsert_remote_actor(pool: &Pool, actor: &RemoteActor) -> anyhow::Result<i64> {
+    let transport = actor.transport().to_string();
+    let remote_user_id = actor.remote_id().to_string();
+    let display_name = actor.display_name().to_string();
+    let avatar_url = actor.avatar_url().map(ToOwned::to_owned);
+    let conn = pool.get().await?;
+    conn.interact(move |conn| -> anyhow::Result<i64> {
+        conn.execute(
+            "INSERT INTO remote_actors (transport, remote_user_id, latest_display_name, latest_avatar_url)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(transport, remote_user_id) DO UPDATE SET
+               latest_display_name = excluded.latest_display_name,
+               latest_avatar_url = excluded.latest_avatar_url,
+               updated_at = CURRENT_TIMESTAMP",
+            rusqlite::params![transport.clone(), remote_user_id.clone(), display_name, avatar_url],
+        )?;
+        Ok(conn.query_row(
+            "SELECT id FROM remote_actors WHERE transport = ?1 AND remote_user_id = ?2",
+            rusqlite::params![transport, remote_user_id],
+            |row| row.get(0),
+        )?)
+    })
+    .await
+    .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+}
+
+pub(crate) async fn upsert_irc_presence(
+    pool: &Pool,
+    actor: &RemoteActor,
+    preferred_nick: Option<&str>,
+    last_successful_nick: Option<&str>,
+    collision_suffix: i64,
+    mark_active: bool,
+) -> anyhow::Result<()> {
+    let actor_id = upsert_remote_actor(pool, actor).await?;
+    let preferred_nick = preferred_nick.map(ToOwned::to_owned);
+    let last_successful_nick = last_successful_nick.map(ToOwned::to_owned);
+    let conn = pool.get().await?;
+    conn.interact(move |conn| -> anyhow::Result<()> {
+        conn.execute(
+            "INSERT INTO irc_presences (remote_actor_id, preferred_nick, last_successful_nick, collision_suffix, last_seen_at, last_active_at)
+             VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP, CASE WHEN ?5 THEN CURRENT_TIMESTAMP ELSE NULL END)
+             ON CONFLICT(remote_actor_id) DO UPDATE SET
+               preferred_nick = COALESCE(excluded.preferred_nick, irc_presences.preferred_nick),
+               last_successful_nick = COALESCE(excluded.last_successful_nick, irc_presences.last_successful_nick),
+               collision_suffix = excluded.collision_suffix,
+               last_seen_at = CURRENT_TIMESTAMP,
+               last_active_at = CASE WHEN ?5 THEN CURRENT_TIMESTAMP ELSE irc_presences.last_active_at END,
+               updated_at = CURRENT_TIMESTAMP",
+            rusqlite::params![actor_id, preferred_nick, last_successful_nick, collision_suffix, mark_active],
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+}
+
+pub(crate) async fn load_irc_presence(
+    pool: &Pool,
+    actor: &RemoteActor,
+) -> anyhow::Result<Option<(Option<String>, Option<String>, i64)>> {
+    let transport = actor.transport().to_string();
+    let remote_user_id = actor.remote_id().to_string();
+    let conn = pool.get().await?;
+    conn.interact(
+        move |conn| -> anyhow::Result<Option<(Option<String>, Option<String>, i64)>> {
+            let mut stmt = conn.prepare(
+                "SELECT p.preferred_nick, p.last_successful_nick, p.collision_suffix
+             FROM irc_presences p
+             JOIN remote_actors a ON a.id = p.remote_actor_id
+             WHERE a.transport = ?1 AND a.remote_user_id = ?2",
+            )?;
+            let mut rows =
+                stmt.query(rusqlite::params![transport.clone(), remote_user_id.clone()])?;
+            if let Some(row) = rows.next()? {
+                Ok(Some((row.get(0)?, row.get(1)?, row.get(2)?)))
+            } else {
+                Ok(None)
+            }
+        },
+    )
+    .await
+    .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
 }
 
 #[derive(Clone, Debug)]
@@ -351,7 +437,44 @@ pub async fn inner_main() -> anyhow::Result<()> {
                                                        'now', 
                                                        'localtime'))
                                            );
-                                        CREATE TRIGGER updatemodtime
+                             CREATE TABLE identity_groups (
+                                           id INTEGER PRIMARY KEY,
+                                           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                           );
+                             CREATE TABLE remote_actors (
+                                           id INTEGER PRIMARY KEY,
+                                           transport TEXT NOT NULL,
+                                           remote_user_id TEXT NOT NULL,
+                                           latest_display_name TEXT NOT NULL,
+                                           latest_avatar_url TEXT,
+                                           identity_group_id INTEGER,
+                                           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           UNIQUE(transport, remote_user_id),
+                                           FOREIGN KEY(identity_group_id) REFERENCES identity_groups(id)
+                                           );
+                             CREATE TABLE linked_identities (
+                                           id INTEGER PRIMARY KEY,
+                                           identity_group_id INTEGER NOT NULL,
+                                           remote_actor_id INTEGER NOT NULL,
+                                           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           UNIQUE(identity_group_id, remote_actor_id),
+                                           FOREIGN KEY(identity_group_id) REFERENCES identity_groups(id),
+                                           FOREIGN KEY(remote_actor_id) REFERENCES remote_actors(id)
+                                           );
+                             CREATE TABLE irc_presences (
+                                           remote_actor_id INTEGER PRIMARY KEY,
+                                           preferred_nick TEXT,
+                                           last_successful_nick TEXT,
+                                           collision_suffix INTEGER NOT NULL DEFAULT 0,
+                                           last_seen_at TEXT,
+                                           last_active_at TEXT,
+                                           created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                           FOREIGN KEY(remote_actor_id) REFERENCES remote_actors(id)
+                                           );
+                             CREATE TRIGGER updatemodtime
                                         BEFORE update ON messages
                                         begin
                                         update messages set modtime 
@@ -373,6 +496,46 @@ pub async fn inner_main() -> anyhow::Result<()> {
                 if !ircid_exists {
                     conn.execute("ALTER TABLE messages ADD COLUMN ircid TEXT", [])?;
                 }
+
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS identity_groups (
+                         id INTEGER PRIMARY KEY,
+                         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                     );
+                     CREATE TABLE IF NOT EXISTS remote_actors (
+                         id INTEGER PRIMARY KEY,
+                         transport TEXT NOT NULL,
+                         remote_user_id TEXT NOT NULL,
+                         latest_display_name TEXT NOT NULL,
+                         latest_avatar_url TEXT,
+                         identity_group_id INTEGER,
+                         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         UNIQUE(transport, remote_user_id),
+                         FOREIGN KEY(identity_group_id) REFERENCES identity_groups(id)
+                     );
+                     CREATE TABLE IF NOT EXISTS linked_identities (
+                         id INTEGER PRIMARY KEY,
+                         identity_group_id INTEGER NOT NULL,
+                         remote_actor_id INTEGER NOT NULL,
+                         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         UNIQUE(identity_group_id, remote_actor_id),
+                         FOREIGN KEY(identity_group_id) REFERENCES identity_groups(id),
+                         FOREIGN KEY(remote_actor_id) REFERENCES remote_actors(id)
+                     );
+                     CREATE TABLE IF NOT EXISTS irc_presences (
+                         remote_actor_id INTEGER PRIMARY KEY,
+                         preferred_nick TEXT,
+                         last_successful_nick TEXT,
+                         collision_suffix INTEGER NOT NULL DEFAULT 0,
+                         last_seen_at TEXT,
+                         last_active_at TEXT,
+                         created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         FOREIGN KEY(remote_actor_id) REFERENCES remote_actors(id)
+                     );",
+                )?;
 
                 Ok(
                     match conn.query_row(

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -23,7 +23,7 @@ use tokio::{net::TcpStream, sync::broadcast};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 use tokio_tungstenite::*;
 
-use crate::{Message, RemoteActor, ThreadRef};
+use crate::{upsert_remote_actor, Message, RemoteActor, ThreadRef};
 
 pub mod objects;
 use objects::{Message as SlackMessage, *};
@@ -1727,10 +1727,14 @@ impl Slack {
             .id
             .clone()
             .ok_or_else(|| anyhow!("No user ID in user info response."))?;
+        let actor = RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url);
+        if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+            eprintln!("Failed to upsert Slack actor: {}", e);
+        }
         let message = Message::Action {
             sender: self.transport_id,
             pipo_id,
-            actor: RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url),
+            actor,
             thread: None,
             message: message,
             attachments: None,
@@ -2047,10 +2051,14 @@ impl Slack {
                 },
             );
 
+            let actor = RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url);
+            if let Err(e) = upsert_remote_actor(&self.pool, &actor).await {
+                eprintln!("Failed to upsert Slack actor: {}", e);
+            }
             let message = Message::Text {
                 pipo_id,
                 sender: self.transport_id,
-                actor: RemoteActor::new(TRANSPORT_NAME, user_id, username, avatar_url),
+                actor,
                 thread,
                 message: message,
                 attachments,


### PR DESCRIPTION
### Motivation
- The codebase stored identity/projection state only indirectly via the `messages` table, making actor presence and IRC nick decisions ephemeral and recomputed on reconnects.
- Introduce explicit schema and helpers so transports can persist actor metadata and IRC-specific projection state keyed by stable transport-local identity.

### Description
- Add persistent schema for `remote_actors`, `irc_presences`, `identity_groups`, and `linked_identities` during DB bootstrap and migrations by extending the SQLite setup in `src/lib.rs` and adding `CREATE TABLE IF NOT EXISTS` statements for the new tables.
- Implement helper DB functions `upsert_remote_actor`, `upsert_irc_presence`, and `load_irc_presence` in `src/lib.rs` that use the `deadpool_sqlite::Pool` for async upsert/load operations.
- Update transport ingestion paths to persist actor rows when user-originated events are received: call `upsert_remote_actor` from `src/discord.rs` and `src/slack.rs` before broadcasting messages and reactions.
- Change IRC logic in `src/irc.rs` so inbound `PRIVMSG`/`NOTICE` events upsert their `remote_actor` and `irc_presences`; and update the per-actor `SessionManager` to load prior nick/projection state via `load_irc_presence` and to write back changed nick/collision state with `upsert_irc_presence` so reconnects reuse prior nick decisions.

### Testing
- Ran `cargo check --message-format=short` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc773b39dc8331b2a460bf04f34082)