### PR TITLE
Feature/threads improvements (#285)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "webpki-roots",
 ]
 
@@ -2014,7 +2014,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2456,7 +2456,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2631,16 +2631,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite 0.28.0",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -2801,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2814,7 +2814,6 @@ dependencies = [
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -3130,7 +3129,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10"
 tokio = { version = "1.43", features = ["full"] }
 tokio-rustls = "0.26"
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
 webpki-roots = "1.0"
 
 [build-dependencies]

--- a/README.org
+++ b/README.org
@@ -34,3 +34,32 @@ cargo run
 - CI clean-regeneration drift checks run on the checked-out commit and only fail when build steps mutate tracked files unexpectedly (not because the PR contains committed changes).
 - CI uses lockfile-locked cargo invocations (e.g. =cargo build --locked=) to avoid dependency-resolution drift between environments.
 - CI is expected to pass with protobuf runtime =\>= 3.7.2=.
+
+
+** IRC threading presentation tuning
+For IRC transports, threaded message presentation can be tuned per transport entry:
+- =thread_presentation_mode=: controls how thread context is represented.
+  - =auto= (default): use IRCv3 =+draft/reply= when available, otherwise emit plaintext fallback context.
+  - =ircv3_only=: only emit IRCv3 reply tags; no plaintext fallback when tags are unavailable.
+  - =plaintext_only=: always emit plaintext context and never emit IRCv3 reply tags.
+- =thread_fallback_style= (default =compact=): controls plaintext fallback formatting for replies.
+  - =compact=: emit tokenized reply prefixes such as =↪ [t:K7F2] alice=.
+  - =verbose=: always include the excerpt in fallback, e.g. =↪ [t:K7F2] alice: original root excerpt...=.
+- =thread_context_repeat= (default =first_seen=): controls when expanded context lines are repeated per channel.
+  - =first_seen=: emit one expanded context line for a token the first time it appears in a channel; later replies use compact token prefixes.
+  - =always=: always emit expanded context lines.
+  - =never=: never emit expanded context lines; always use compact token prefixes.
+- =thread_excerpt_len= (default =120=): max character count used for plaintext thread root excerpts.
+- =show_thread_root_marker= (default =true=): when plaintext mode is used for the root post itself, include the =[thread]= marker.
+
+Migration behavior:
+- Existing configs continue to work without changes.
+- If new fields are omitted, defaults are applied (=thread_fallback_style= → =compact=, =thread_context_repeat= → =first_seen=).
+- =first_seen= gives one richer intro line per thread token/channel, then shifts to concise token-only context to reduce noise.
+- Set =verbose +=always= to approximate the prior always-expanded fallback behavior.
+
+IRC user commands for thread replies:
+- =/threads=: shows a bounded list of recent active thread tokens for the current channel (latest 8), with short root summaries.
+- =/threadhelp= (and =/help=): shows reply syntax examples.
+- Reply syntax: =>>TOKEN message= or =/reply TOKEN message=.
+- First-seen fallback context in =first_seen= mode includes a one-time hint like =reply with: >>K7F2 <message>=.

--- a/docs/irc-threading-modes.md
+++ b/docs/irc-threading-modes.md
@@ -1,0 +1,32 @@
+# IRC thread presentation modes
+
+Pipo supports configurable IRC thread presentation for each IRC transport block.
+
+## Config keys
+
+- `thread_presentation_mode` (`auto` | `ircv3_only` | `plaintext_only`)
+  - `auto` (default): use IRCv3 `+draft/reply` tags when available and resolvable; fallback to plaintext prefixes otherwise.
+  - `ircv3_only`: only use IRCv3 reply tags. If unavailable/unresolvable, no plaintext thread prefix is emitted.
+  - `plaintext_only`: always emit plaintext thread prefixes; IRCv3 reply tags are never used.
+- `thread_excerpt_len` (default: `120`)
+  - Max character length for plaintext root excerpts in `↪ reply to ...` prefixes.
+- `show_thread_root_marker` (default: `true`)
+  - Controls whether root messages include `[thread]` in plaintext mode.
+
+## Migration and operator guidance
+
+These options are optional and backward-compatible.
+If omitted, behavior is equivalent to the previous default (`auto` with plaintext fallback and excerpt length 120).
+
+Use `plaintext_only` on legacy networks lacking IRCv3 support when consistent visible context is required.
+Use `ircv3_only` when operators want clean messages with no plaintext prefixes and accept that some replies may appear unthreaded on older servers.
+
+## Logging
+
+For each outbound threaded message, Pipo logs the selected mode as one of:
+
+- `ircv3_tag`
+- `plaintext_fallback`
+- `ircv3_unavailable`
+
+The log line intentionally includes only transport/channel/id metadata and mode, without message content.

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -24,7 +24,7 @@ use serenity::{
 use tokio::sync::{broadcast, Mutex as AsyncMutex};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 
-use crate::Message;
+use crate::{Message, ThreadRef};
 
 const TRANSPORT_NAME: &'static str = "Discord";
 
@@ -266,7 +266,10 @@ impl RealHandler {
                     {
                         Some(webhook) => webhook,
                         None => match channel_id
-                            .create_webhook(http, CreateWebhook::new(format!("PIPO {}", channel_id)))
+                            .create_webhook(
+                                http,
+                                CreateWebhook::new(format!("PIPO {}", channel_id)),
+                            )
                             .await
                         {
                             Ok(webhook) => webhook,
@@ -856,12 +859,16 @@ impl RealHandler {
     async fn get_sender_and_thread(
         &self,
         channel_id: ChannelId,
-        thread: &mut Option<(Option<String>, Option<u64>)>,
+        thread: &mut Option<ThreadRef>,
     ) -> Option<broadcast::Sender<Message>> {
         if let Some(sender) = self.shared.get_sender(channel_id) {
             return Some(sender);
         } else if let Some(parent) = self.shared.get_thread(channel_id) {
-            *thread = Some((None, Some(channel_id.get())));
+            *thread = Some(ThreadRef {
+                origin_transport: TRANSPORT_NAME.to_string(),
+                reply_target_id: Some(channel_id.get()),
+                ..Default::default()
+            });
 
             return self.shared.get_sender(parent);
         } else {
@@ -946,7 +953,9 @@ impl RealHandler {
 
                                 let user = if let Ok(id) = id.parse() {
                                     if is_role {
-                                        if let Ok(roles) = http.get_guild_roles(GuildId::new(guild_id)).await {
+                                        if let Ok(roles) =
+                                            http.get_guild_roles(GuildId::new(guild_id)).await
+                                        {
                                             if let Some(role) =
                                                 roles.into_iter().find(|r| r.id == RoleId::new(id))
                                             {
@@ -958,7 +967,10 @@ impl RealHandler {
                                             "Unknown".to_string()
                                         }
                                     } else if is_nickname {
-                                        match http.get_member(GuildId::new(guild_id), UserId::new(id)).await {
+                                        match http
+                                            .get_member(GuildId::new(guild_id), UserId::new(id))
+                                            .await
+                                        {
                                             Ok(m) => {
                                                 if let Some(n) = m.nick {
                                                     n
@@ -1074,7 +1086,10 @@ impl RealHandler {
                             }
 
                             name = if let Ok(id) = id.parse() {
-                                if let Ok(e) = http.get_emoji(GuildId::new(guild_id), EmojiId::new(id)).await {
+                                if let Ok(e) = http
+                                    .get_emoji(GuildId::new(guild_id), EmojiId::new(id))
+                                    .await
+                                {
                                     e.name
                                 } else {
                                     name
@@ -1133,7 +1148,10 @@ impl RealHandler {
                                     }
 
                                     name = if let Ok(id) = id.parse() {
-                                        if let Ok(e) = http.get_emoji(GuildId::new(guild_id), EmojiId::new(id)).await {
+                                        if let Ok(e) = http
+                                            .get_emoji(GuildId::new(guild_id), EmojiId::new(id))
+                                            .await
+                                        {
                                             e.name
                                         } else {
                                             name
@@ -1272,7 +1290,12 @@ impl EventHandler for Handler {
             .await;
     }
 
-    async fn channel_update(&self, _ctx: Context, _old: Option<GuildChannel>, channel: GuildChannel) {
+    async fn channel_update(
+        &self,
+        _ctx: Context,
+        _old: Option<GuildChannel>,
+        channel: GuildChannel,
+    ) {
         eprintln!("Channel updated: {}", channel);
     }
 
@@ -1321,7 +1344,13 @@ impl EventHandler for Handler {
             .await;
     }
 
-    async fn message_update(&self, ctx: Context, _old_if_available: Option<SerenityMessage>, _new_if_available: Option<SerenityMessage>, msg: MessageUpdateEvent) {
+    async fn message_update(
+        &self,
+        ctx: Context,
+        _old_if_available: Option<SerenityMessage>,
+        _new_if_available: Option<SerenityMessage>,
+        msg: MessageUpdateEvent,
+    ) {
         self.real_handler
             .lock()
             .await
@@ -1548,7 +1577,13 @@ impl Discord {
                     None => String::from("New Thread"),
                 };
                 let ret = channel
-                    .create_thread_from_message(http, id, CreateThread::new(name).auto_archive_duration(AutoArchiveDuration::OneDay).kind(ChannelType::PublicThread))
+                    .create_thread_from_message(
+                        http,
+                        id,
+                        CreateThread::new(name)
+                            .auto_archive_duration(AutoArchiveDuration::OneDay)
+                            .kind(ChannelType::PublicThread),
+                    )
                     .await;
 
                 if let Ok(thread) = ret {
@@ -1627,7 +1662,11 @@ impl Discord {
             if let Some(id) = id {
                 if let Ok(wh) = WebhookId::from(id).to_webhook(http).await {
                     if let Ok(msg) = wh
-                        .edit_message(http, msgid, EditWebhookMessage::new().content(content.to_string()))
+                        .edit_message(
+                            http,
+                            msgid,
+                            EditWebhookMessage::new().content(content.to_string()),
+                        )
                         .await
                     {
                         return self.update_messages_table(pipo_id, msg).await;
@@ -1758,7 +1797,7 @@ impl Discord {
         transport: String,
         username: String,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
         is_edit: bool,
@@ -1770,7 +1809,10 @@ impl Discord {
         let mut content = MessageBuilder::new();
         let http = self.cache_http.as_ref().unwrap().http();
         let channel = match thread {
-            Some((s, _)) => self.get_threadid(channel, s, &message).await?,
+            Some(thread_ref) => {
+                self.get_threadid(channel, thread_ref.thread_root_id, &message)
+                    .await?
+            }
             None => channel,
         };
 
@@ -1818,7 +1860,11 @@ impl Discord {
             if let Some(id) = id {
                 if let Ok(wh) = WebhookId::from(id).to_webhook(http).await {
                     if let Ok(msg) = wh
-                        .edit_message(http, msgid, EditWebhookMessage::new().content(content.to_string()))
+                        .edit_message(
+                            http,
+                            msgid,
+                            EditWebhookMessage::new().content(content.to_string()),
+                        )
                         .await
                     {
                         return self.update_messages_table(pipo_id, msg).await;
@@ -2172,6 +2218,13 @@ mod tests {
             .await;
 
         assert!(sender.is_some());
-        assert_eq!(thread, Some((None, Some(66))));
+        assert_eq!(
+            thread,
+            Some(ThreadRef {
+                origin_transport: TRANSPORT_NAME.to_string(),
+                reply_target_id: Some(66),
+                ..Default::default()
+            })
+        );
     }
 }

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -1,23 +1,68 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 
 use deadpool_sqlite::Pool;
 use irc::{
     client::prelude::{Client, Command, Config, Prefix},
-    proto::caps::Capability,
+    proto::{caps::Capability, command::CapSubCommand, message::Tag, Message as IrcMessage},
 };
 use lazy_static::lazy_static;
 use regex::Regex;
 use rusqlite::params;
+use serde::Deserialize;
 use tokio::sync::broadcast;
 use tokio_stream::{wrappers::BroadcastStream, StreamMap};
 
-use crate::{Attachment, Message};
+use crate::{Attachment, Message, ThreadRef};
 use anyhow::anyhow;
 
 const TRANSPORT_NAME: &'static str = "IRC";
+const DEFAULT_THREAD_EXCERPT_LEN: usize = 120;
+const REPLY_TOKEN_TTL: Duration = Duration::from_secs(60 * 60 * 6);
+const THREAD_LIST_LIMIT: usize = 8;
+
+#[derive(Clone, Debug)]
+struct ReplyTokenEntry {
+    thread_ref: ThreadRef,
+    nickname: Option<String>,
+    created_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ThreadPresentationMode {
+    #[default]
+    Auto,
+    Ircv3Only,
+    PlaintextOnly,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ThreadFallbackStyle {
+    #[default]
+    Compact,
+    Verbose,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ThreadContextRepeat {
+    #[default]
+    FirstSeen,
+    Always,
+    Never,
+}
+
+#[derive(Debug)]
+struct ThreadPresentation {
+    reply_target: Option<String>,
+    plaintext_prefix: Option<String>,
+    mode_used: &'static str,
+}
 
 pub(crate) struct IRC {
     transport_id: usize,
@@ -26,6 +71,20 @@ pub(crate) struct IRC {
     channels: HashMap<String, broadcast::Sender<Message>>,
     pool: Pool,
     pipo_id: Arc<Mutex<i64>>,
+    capabilities: IrcCapabilityState,
+    thread_presentation_mode: ThreadPresentationMode,
+    thread_fallback_style: ThreadFallbackStyle,
+    thread_context_repeat: ThreadContextRepeat,
+    thread_excerpt_len: usize,
+    show_thread_root_marker: bool,
+    seen_thread_tokens: Arc<Mutex<HashMap<String, HashSet<String>>>>,
+    reply_tokens: Arc<Mutex<HashMap<(String, String), ReplyTokenEntry>>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct IrcCapabilityState {
+    supports_message_tags: bool,
+    supports_reply_tags: bool,
 }
 
 impl IRC {
@@ -38,6 +97,11 @@ impl IRC {
         use_tls: bool,
         img_root: &str,
         channel_mapping: &HashMap<Arc<String>, Arc<String>>,
+        thread_presentation_mode: ThreadPresentationMode,
+        thread_fallback_style: ThreadFallbackStyle,
+        thread_context_repeat: ThreadContextRepeat,
+        thread_excerpt_len: usize,
+        show_thread_root_marker: bool,
         transport_id: usize,
     ) -> anyhow::Result<IRC> {
         let channels = channel_mapping
@@ -76,6 +140,18 @@ impl IRC {
             transport_id,
             pool,
             pipo_id,
+            capabilities: IrcCapabilityState::default(),
+            thread_presentation_mode,
+            thread_fallback_style,
+            thread_context_repeat,
+            thread_excerpt_len: if thread_excerpt_len == 0 {
+                DEFAULT_THREAD_EXCERPT_LEN
+            } else {
+                thread_excerpt_len
+            },
+            show_thread_root_marker,
+            seen_thread_tokens: Arc::new(Mutex::new(HashMap::new())),
+            reply_tokens: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -92,11 +168,11 @@ impl IRC {
                     match message {
                         Message::Action {
                         sender,
-                        pipo_id: _,
+                        pipo_id,
                         transport,
                         username,
                         avatar_url: _,
-                        thread: _,
+                        thread,
                         message,
                         attachments,
                         is_edit,
@@ -105,12 +181,14 @@ impl IRC {
                         if sender != self.transport_id {
                             self.handle_action_message(&client,
                                            &channel,
+                                           pipo_id,
                                            transport,
                                            username,
+                                           thread,
                                            message,
                                            attachments,
                                            is_edit,
-                                           irc_flag);
+                                           irc_flag).await;
                         }
                         },
                         Message::Bot {
@@ -171,11 +249,11 @@ impl IRC {
                         },
                         Message::Text {
                         sender,
-                        pipo_id: _,
+                        pipo_id,
                         transport,
                         username,
                         avatar_url: _,
-                        thread: _,
+                        thread,
                         message,
                         attachments,
                         is_edit,
@@ -184,12 +262,14 @@ impl IRC {
                         if sender != self.transport_id {
                             self.handle_text_message(&client,
                                          &channel,
+                                         pipo_id,
                                          transport,
                                          username,
+                                         thread,
                                          message,
                                          attachments,
                                          is_edit,
-                                         irc_flag);
+                                         irc_flag).await;
                         }
                         },
                     }
@@ -203,15 +283,21 @@ impl IRC {
                     }
                     let message = message.unwrap();
                     let nickname = match message.prefix {
-                        Some(Prefix::Nickname(nickname, _, _)) => nickname,
-                        Some(Prefix::ServerName(servername)) => servername,
+                        Some(Prefix::Nickname(ref nickname, _, _)) => nickname.to_string(),
+                        Some(Prefix::ServerName(ref servername)) => servername.to_string(),
                         None => "".to_string(),
                     };
+                    self.update_capabilities_from_message(&message);
+
+                    let irc_message_id = IRC::parse_message_id_tag(&message);
+
                     if let Command::PRIVMSG(channel, message)
                         = message.command {
-                        if let Err(e) = self.handle_priv_msg(nickname,
+                        if let Err(e) = self.handle_priv_msg(&client,
+                                             nickname,
                                              channel,
-                                             message)
+                                             message,
+                                             irc_message_id)
                             .await {
                             eprintln!("Error handling PRIVMSG: {}",
                                   e);
@@ -221,7 +307,8 @@ impl IRC {
                         = message.command {
                         if let Err(e) = self.handle_notice(nickname,
                                            channel,
-                                           message)
+                                           message,
+                                           irc_message_id)
                             .await {
                             eprintln!("Error handling NOTICE: {}",
                                   e);
@@ -234,17 +321,20 @@ impl IRC {
         }
     }
 
-    fn handle_action_message(
+    async fn handle_action_message(
         &self,
         client: &Client,
         channel: &str,
+        pipo_id: i64,
         transport: String,
         username: String,
+        thread: Option<crate::ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
         is_edit: bool,
         irc_flag: bool,
     ) {
+        let irc_message_id = self.ensure_ircid_for_pipo_id(pipo_id).await;
         let mut message = message;
 
         if irc_flag && is_edit {
@@ -252,6 +342,38 @@ impl IRC {
         }
         if let Some(message) = message {
             let mut is_edit = is_edit;
+            let thread_presentation = self
+                .resolve_thread_presentation(channel, pipo_id, &thread)
+                .await;
+
+            if thread.is_some() {
+                self.log_thread_presentation(channel, pipo_id, &thread_presentation);
+            }
+
+            if let Some(prefix) = thread_presentation.plaintext_prefix.as_ref() {
+                let prefix_message = format!(
+                    "\x01ACTION \x02* \x02{}!\x02{}\x02 {}\x01",
+                    &transport[..1].to_uppercase(),
+                    username,
+                    prefix
+                );
+
+                if let Err(e) = self
+                    .send_privmsg_with_tags(
+                        client,
+                        channel,
+                        prefix_message.clone(),
+                        thread_presentation.reply_target.as_deref(),
+                        irc_message_id.as_deref(),
+                    )
+                    .await
+                {
+                    eprintln!(
+                        "Failed to send message '{}' channel {}: {:#}",
+                        prefix_message, channel, e
+                    );
+                }
+            }
 
             for msg in message.split("\n") {
                 if msg == "" {
@@ -276,7 +398,16 @@ impl IRC {
                     )
                 };
 
-                if let Err(e) = client.send_privmsg(channel.clone(), message.clone()) {
+                if let Err(e) = self
+                    .send_privmsg_with_tags(
+                        client,
+                        channel,
+                        message.clone(),
+                        thread_presentation.reply_target.as_deref(),
+                        irc_message_id.as_deref(),
+                    )
+                    .await
+                {
                     eprintln!(
                         "Failed to send message '{}' channel {}: {:#}",
                         message, channel, e
@@ -338,17 +469,20 @@ impl IRC {
         }
     }
 
-    fn handle_text_message(
+    async fn handle_text_message(
         &self,
         client: &Client,
         channel: &str,
+        pipo_id: i64,
         transport: String,
         username: String,
+        thread: Option<crate::ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
         is_edit: bool,
         irc_flag: bool,
     ) {
+        let irc_message_id = self.ensure_ircid_for_pipo_id(pipo_id).await;
         let mut message = message;
 
         if irc_flag && is_edit {
@@ -356,6 +490,38 @@ impl IRC {
         }
         if let Some(message) = message {
             let mut is_edit = is_edit;
+            let thread_presentation = self
+                .resolve_thread_presentation(channel, pipo_id, &thread)
+                .await;
+
+            if thread.is_some() {
+                self.log_thread_presentation(channel, pipo_id, &thread_presentation);
+            }
+
+            if let Some(prefix) = thread_presentation.plaintext_prefix.as_ref() {
+                let prefix_message = format!(
+                    "\x01ACTION <{}!\x02{}\x02> {}\x01",
+                    &transport[..1].to_uppercase(),
+                    username,
+                    prefix
+                );
+
+                if let Err(e) = self
+                    .send_privmsg_with_tags(
+                        client,
+                        channel,
+                        prefix_message.clone(),
+                        thread_presentation.reply_target.as_deref(),
+                        irc_message_id.as_deref(),
+                    )
+                    .await
+                {
+                    eprintln!(
+                        "Failed to send message '{}' channel {}: {:#}",
+                        prefix_message, channel, e
+                    );
+                }
+            }
 
             for msg in message.split("\n") {
                 if msg == "" {
@@ -380,7 +546,16 @@ impl IRC {
                     )
                 };
 
-                if let Err(e) = client.send_privmsg(channel.clone(), message.clone()) {
+                if let Err(e) = self
+                    .send_privmsg_with_tags(
+                        client,
+                        channel,
+                        message.clone(),
+                        thread_presentation.reply_target.as_deref(),
+                        irc_message_id.as_deref(),
+                    )
+                    .await
+                {
                     eprintln!(
                         "Failed to send message '{}' channel {}: {:#}",
                         message, channel, e
@@ -461,7 +636,15 @@ impl IRC {
     )> {
         let mut client = Client::from_config(self.config.clone()).await?;
 
-        client.send_cap_req(&[Capability::MultiPrefix])?;
+        self.capabilities = IrcCapabilityState::default();
+
+        client.send_cap_req(&[
+            Capability::MultiPrefix,
+            Capability::Custom("message-tags"),
+            Capability::Custom("draft/reply"),
+            Capability::ServerTime,
+            Capability::EchoMessage,
+        ])?;
         client.identify()?;
 
         let irc_stream = client.stream()?;
@@ -477,6 +660,513 @@ impl IRC {
         }
 
         Ok((client, irc_stream, input_buses))
+    }
+
+    fn update_capabilities_from_message(&mut self, message: &IrcMessage) {
+        let Command::CAP(_, subcommand, _, Some(extensions)) = &message.command else {
+            return;
+        };
+
+        if *subcommand != CapSubCommand::ACK {
+            return;
+        }
+
+        for capability in extensions.split_whitespace() {
+            match capability {
+                "message-tags" => self.capabilities.supports_message_tags = true,
+                "draft/reply" | "reply" => self.capabilities.supports_reply_tags = true,
+                _ => continue,
+            }
+        }
+    }
+
+    async fn send_privmsg_with_tags(
+        &self,
+        client: &Client,
+        channel: &str,
+        message: String,
+        reply_target: Option<&str>,
+        irc_message_id: Option<&str>,
+    ) -> irc::error::Result<()> {
+        let tags = self.tags_for_outbound_message(reply_target, irc_message_id);
+
+        if let Some(tags) = tags {
+            return client.send(IrcMessage {
+                tags: Some(tags),
+                prefix: None,
+                command: Command::PRIVMSG(channel.to_string(), message),
+            });
+        }
+
+        client.send_privmsg(channel, message)
+    }
+
+    fn tags_for_outbound_message(
+        &self,
+        reply_target: Option<&str>,
+        irc_message_id: Option<&str>,
+    ) -> Option<Vec<Tag>> {
+        if !self.capabilities.supports_message_tags {
+            return None;
+        }
+
+        let mut tags = Vec::new();
+
+        if let Some(irc_message_id) = irc_message_id {
+            tags.push(Tag(
+                "draft/msgid".to_string(),
+                Some(irc_message_id.to_string()),
+            ));
+        }
+
+        if !self.capabilities.supports_reply_tags {
+            return if tags.is_empty() { None } else { Some(tags) };
+        }
+
+        if let Some(reply_target) = reply_target {
+            tags.push(Tag(
+                "+draft/reply".to_string(),
+                Some(reply_target.to_string()),
+            ));
+        }
+
+        if tags.is_empty() {
+            None
+        } else {
+            Some(tags)
+        }
+    }
+
+    async fn resolve_thread_presentation(
+        &self,
+        channel: &str,
+        pipo_id: i64,
+        thread: &Option<ThreadRef>,
+    ) -> ThreadPresentation {
+        if thread.is_none() {
+            return ThreadPresentation {
+                reply_target: None,
+                plaintext_prefix: None,
+                mode_used: "none",
+            };
+        }
+
+        self.remember_reply_token(channel, thread, None);
+
+        let can_use_reply_tags = self.capabilities.supports_message_tags
+            && self.capabilities.supports_reply_tags
+            && !matches!(
+                self.thread_presentation_mode,
+                ThreadPresentationMode::PlaintextOnly
+            );
+        let reply_target = if can_use_reply_tags {
+            self.resolve_irc_reply_target(thread).await
+        } else {
+            None
+        };
+
+        match self.thread_presentation_mode {
+            ThreadPresentationMode::Auto => {
+                if reply_target.is_some() {
+                    ThreadPresentation {
+                        reply_target,
+                        plaintext_prefix: None,
+                        mode_used: "ircv3_tag",
+                    }
+                } else {
+                    ThreadPresentation {
+                        reply_target: None,
+                        plaintext_prefix: self
+                            .outbound_thread_fallback_prefix(channel, pipo_id, thread)
+                            .await,
+                        mode_used: "plaintext_fallback",
+                    }
+                }
+            }
+            ThreadPresentationMode::Ircv3Only => {
+                if reply_target.is_some() {
+                    ThreadPresentation {
+                        reply_target,
+                        plaintext_prefix: None,
+                        mode_used: "ircv3_tag",
+                    }
+                } else {
+                    ThreadPresentation {
+                        reply_target: None,
+                        plaintext_prefix: None,
+                        mode_used: "ircv3_unavailable",
+                    }
+                }
+            }
+            ThreadPresentationMode::PlaintextOnly => ThreadPresentation {
+                reply_target: None,
+                plaintext_prefix: self
+                    .outbound_thread_fallback_prefix(channel, pipo_id, thread)
+                    .await,
+                mode_used: "plaintext_fallback",
+            },
+        }
+    }
+
+    fn log_thread_presentation(
+        &self,
+        channel: &str,
+        pipo_id: i64,
+        thread_presentation: &ThreadPresentation,
+    ) {
+        eprintln!(
+            "IRC threaded message routing: transport_id={} channel={} pipo_id={} mode={}",
+            self.transport_id, channel, pipo_id, thread_presentation.mode_used
+        );
+    }
+
+    async fn resolve_irc_reply_target(&self, thread: &Option<ThreadRef>) -> Option<String> {
+        let thread_ref = thread.as_ref()?;
+
+        if let Some(thread_root_id) = thread_ref.thread_root_id.clone() {
+            if let Some(ircid) = self.select_ircid_by_slackid(thread_root_id.clone()).await {
+                return Some(ircid);
+            }
+            if let Some(ircid) = self.select_ircid_by_ircid(thread_root_id.clone()).await {
+                return Some(ircid);
+            }
+            if let Ok(id) = thread_root_id.parse::<i64>() {
+                if let Some(ircid) = self.select_ircid_from_messages(id).await {
+                    return Some(ircid);
+                }
+            }
+        }
+
+        if let Some(reply_target_id) = thread_ref.reply_target_id {
+            if let Some(ircid) = self.select_ircid_by_discordid(reply_target_id).await {
+                return Some(ircid);
+            }
+        }
+
+        None
+    }
+
+    async fn outbound_thread_fallback_prefix(
+        &self,
+        channel: &str,
+        pipo_id: i64,
+        thread: &Option<ThreadRef>,
+    ) -> Option<String> {
+        let thread_ref = thread.as_ref()?;
+
+        if self.is_thread_root_message(pipo_id, thread_ref).await {
+            return if self.show_thread_root_marker {
+                Some("[thread]".to_string())
+            } else {
+                None
+            };
+        }
+
+        let root_author = IRC::sanitize_thread_context_text(thread_ref.root_author.as_deref())
+            .filter(|author| !author.is_empty())
+            .unwrap_or_else(|| "unknown".to_string());
+        let root_excerpt = IRC::sanitize_thread_context_text(thread_ref.root_excerpt.as_deref())
+            .filter(|excerpt| !excerpt.is_empty())
+            .map(|excerpt| IRC::truncate_with_ellipsis(excerpt, self.thread_excerpt_len))
+            .unwrap_or_else(|| "…".to_string());
+        let thread_token = IRC::thread_token(thread_ref);
+        let compact_prefix = format!("↪ [t:{}] {}", thread_token, root_author);
+        let expanded_prefix = format!("↪ [t:{}] {}: {}", thread_token, root_author, root_excerpt);
+
+        let emit_expanded = match self.thread_context_repeat {
+            ThreadContextRepeat::Always => true,
+            ThreadContextRepeat::Never => false,
+            ThreadContextRepeat::FirstSeen => self.mark_thread_token_seen(channel, &thread_token),
+        };
+
+        if emit_expanded {
+            if self.thread_context_repeat == ThreadContextRepeat::FirstSeen {
+                Some(format!(
+                    "{} (reply with: >>{} <message>)",
+                    expanded_prefix, thread_token
+                ))
+            } else {
+                Some(expanded_prefix)
+            }
+        } else if self.thread_fallback_style == ThreadFallbackStyle::Verbose {
+            Some(expanded_prefix)
+        } else {
+            Some(compact_prefix)
+        }
+    }
+
+    fn mark_thread_token_seen(&self, channel: &str, token: &str) -> bool {
+        let mut seen = self.seen_thread_tokens.lock().unwrap();
+        let channel_seen = seen.entry(channel.to_string()).or_default();
+        channel_seen.insert(token.to_string())
+    }
+
+    fn remember_reply_token(
+        &self,
+        channel: &str,
+        thread: &Option<ThreadRef>,
+        nickname: Option<&str>,
+    ) {
+        let Some(thread_ref) = thread.as_ref() else {
+            return;
+        };
+
+        let token = IRC::thread_token(thread_ref);
+        let mut tokens = self.reply_tokens.lock().unwrap();
+        IRC::cleanup_expired_reply_tokens(&mut tokens);
+        tokens.insert(
+            (channel.to_string(), token),
+            ReplyTokenEntry {
+                thread_ref: thread_ref.clone(),
+                nickname: nickname.map(str::to_string),
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    fn cleanup_expired_reply_tokens(tokens: &mut HashMap<(String, String), ReplyTokenEntry>) {
+        let now = Instant::now();
+        tokens.retain(|_, entry| now.duration_since(entry.created_at) < REPLY_TOKEN_TTL);
+    }
+
+    fn resolve_reply_token(
+        &self,
+        channel: &str,
+        nickname: Option<&str>,
+        token: &str,
+    ) -> Option<ThreadRef> {
+        let mut tokens = self.reply_tokens.lock().unwrap();
+        IRC::cleanup_expired_reply_tokens(&mut tokens);
+
+        let key = (channel.to_string(), token.to_uppercase());
+        let entry = tokens.get(&key)?;
+
+        if let (Some(expected), Some(actual)) = (entry.nickname.as_deref(), nickname) {
+            if !expected.eq_ignore_ascii_case(actual) {
+                return None;
+            }
+        }
+
+        Some(entry.thread_ref.clone())
+    }
+
+    fn active_reply_tokens_for_channel(&self, channel: &str) -> Vec<String> {
+        let mut tokens = self.reply_tokens.lock().unwrap();
+        IRC::cleanup_expired_reply_tokens(&mut tokens);
+
+        tokens
+            .keys()
+            .filter(|(token_channel, _)| token_channel == channel)
+            .map(|(_, token)| token.clone())
+            .collect()
+    }
+
+    fn active_reply_token_entries_for_channel(
+        &self,
+        channel: &str,
+    ) -> Vec<(String, ReplyTokenEntry)> {
+        let mut tokens = self.reply_tokens.lock().unwrap();
+        IRC::cleanup_expired_reply_tokens(&mut tokens);
+
+        let mut entries = tokens
+            .iter()
+            .filter(|((token_channel, _), _)| token_channel == channel)
+            .map(|((_, token), entry)| (token.clone(), entry.clone()))
+            .collect::<Vec<_>>();
+
+        entries.sort_by(|a, b| b.1.created_at.cmp(&a.1.created_at));
+        entries
+    }
+
+    fn thread_root_summary(&self, thread_ref: &ThreadRef) -> String {
+        let author = IRC::sanitize_thread_context_text(thread_ref.root_author.as_deref())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "unknown".to_string());
+        let excerpt = IRC::sanitize_thread_context_text(thread_ref.root_excerpt.as_deref())
+            .filter(|value| !value.is_empty())
+            .map(|value| IRC::truncate_with_ellipsis(value, 40))
+            .unwrap_or_else(|| "…".to_string());
+
+        format!("{}: {}", author, excerpt)
+    }
+
+    async fn handle_local_thread_command(
+        &self,
+        client: &Client,
+        channel: &str,
+        message: &str,
+    ) -> anyhow::Result<bool> {
+        let trimmed = message.trim();
+
+        if trimmed.eq_ignore_ascii_case("/threads") {
+            let entries = self.active_reply_token_entries_for_channel(channel);
+            let rendered = if entries.is_empty() {
+                "none cached yet".to_string()
+            } else {
+                entries
+                    .into_iter()
+                    .take(THREAD_LIST_LIMIT)
+                    .map(|(token, entry)| {
+                        format!("{} ({})", token, self.thread_root_summary(&entry.thread_ref))
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            };
+
+            let notice = format!(
+                "Recent thread tokens (latest {}): {}",
+                THREAD_LIST_LIMIT, rendered
+            );
+            client.send_notice(channel, notice)?;
+            return Ok(true);
+        }
+
+        if trimmed.eq_ignore_ascii_case("/threadhelp") || trimmed.eq_ignore_ascii_case("/help") {
+            client.send_notice(
+                channel,
+                "Thread replies: >>TOKEN your reply (example: >>K7F2 thanks) or /reply TOKEN your reply. Use /threads to list recent tokens.",
+            )?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn parse_reply_command(message: &str) -> Option<(String, String)> {
+        let trimmed = message.trim_start();
+        let (token, remaining) = if let Some(command) = trimmed.strip_prefix(">>") {
+            let mut parts = command.splitn(2, char::is_whitespace);
+            let token = parts.next()?.trim();
+            let remaining = parts.next()?.trim_start();
+            (token, remaining)
+        } else if let Some(command) = trimmed.strip_prefix("/reply") {
+            let command = command.trim_start();
+            let mut parts = command.splitn(2, char::is_whitespace);
+            let token = parts.next()?.trim();
+            let remaining = parts.next()?.trim_start();
+            (token, remaining)
+        } else {
+            return None;
+        };
+
+        if token.is_empty() || remaining.is_empty() {
+            return None;
+        }
+
+        if !token.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+            return None;
+        }
+
+        Some((token.to_uppercase(), remaining.to_string()))
+    }
+
+    async fn send_reply_token_usage_notice(&self, client: &Client, channel: &str) {
+        let mut active = self.active_reply_tokens_for_channel(channel);
+        active.sort();
+        let sample = if active.is_empty() {
+            "none currently cached".to_string()
+        } else {
+            active.into_iter().take(8).collect::<Vec<_>>().join(", ")
+        };
+
+        let notice = format!(
+            "Unknown or expired reply token. Usage: >>TOKEN your reply or /reply TOKEN your reply. Discover tokens from [t:TOKEN] thread markers in recent bridged messages. Active tokens: {}",
+            sample
+        );
+
+        if let Err(e) = client.send_notice(channel, notice) {
+            eprintln!(
+                "Failed to send reply-token usage notice to {}: {:#}",
+                channel, e
+            );
+        }
+    }
+
+    fn thread_token(thread_ref: &ThreadRef) -> String {
+        let token_input = thread_ref
+            .thread_root_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string())
+            .or_else(|| thread_ref.reply_target_id.map(|id| id.to_string()))
+            .or_else(|| IRC::sanitize_thread_context_text(thread_ref.root_author.as_deref()))
+            .unwrap_or_else(|| "thread".to_string());
+
+        let mut hash: u32 = 0x811c9dc5;
+        for byte in token_input.as_bytes() {
+            hash ^= u32::from(*byte);
+            hash = hash.wrapping_mul(0x01000193);
+        }
+
+        let base36 = IRC::to_base36(hash.max(1));
+        base36.chars().take(4).collect::<String>()
+    }
+
+    fn to_base36(mut value: u32) -> String {
+        let alphabet = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        let mut out = Vec::new();
+
+        while value > 0 {
+            out.push(alphabet[(value % 36) as usize] as char);
+            value /= 36;
+        }
+
+        out.iter().rev().collect()
+    }
+
+    async fn is_thread_root_message(&self, pipo_id: i64, thread_ref: &ThreadRef) -> bool {
+        let Some(thread_root_id) = thread_ref.thread_root_id.as_deref() else {
+            return false;
+        };
+
+        if let Some(slackid) = self.select_slackid_from_messages(pipo_id).await {
+            if thread_root_id == slackid {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn sanitize_thread_context_text(value: Option<&str>) -> Option<String> {
+        let value = value?;
+        let collapsed = value
+            .chars()
+            .map(|ch| if ch.is_ascii_control() { ' ' } else { ch })
+            .collect::<String>();
+
+        let collapsed = collapsed
+            .split_whitespace()
+            .collect::<Vec<&str>>()
+            .join(" ");
+
+        if collapsed.is_empty() {
+            None
+        } else {
+            Some(collapsed)
+        }
+    }
+
+    fn truncate_with_ellipsis(input: String, max_len: usize) -> String {
+        let char_count = input.chars().count();
+        if char_count <= max_len {
+            return input;
+        }
+
+        let truncated: String = input.chars().take(max_len.saturating_sub(1)).collect();
+        format!("{}…", truncated)
+    }
+
+    fn parse_message_id_tag(message: &IrcMessage) -> Option<String> {
+        let tags = message.tags.as_ref()?;
+
+        tags.iter().find_map(|Tag(key, value)| {
+            if key == "msgid" || key == "+draft/msgid" {
+                value.clone()
+            } else {
+                None
+            }
+        })
     }
 
     async fn get_avatar_url(&self, nickname: &str) -> String {
@@ -499,15 +1189,28 @@ impl IRC {
 
     async fn handle_priv_msg(
         &self,
+        client: &Client,
         nickname: String,
         channel: String,
         message: String,
+        irc_message_id: Option<String>,
     ) -> anyhow::Result<()> {
+        if self
+            .handle_local_thread_command(client, &channel, &message)
+            .await?
+        {
+            return Ok(());
+        }
+
         if let Some(sender) = self.channels.get(&channel) {
             lazy_static! {
                 static ref RE: Regex = Regex::new("^\x01ACTION (.*)\x01\r?$").unwrap();
             }
             let pipo_id = self.insert_into_messages_table().await?;
+            if let Some(irc_message_id) = irc_message_id {
+                self.update_messages_ircid(pipo_id, Some(irc_message_id))
+                    .await?;
+            }
 
             let avatar_url = self.get_avatar_url(&nickname).await;
 
@@ -515,14 +1218,29 @@ impl IRC {
 
             if let Some(message) = RE.captures(&message) {
                 let message = message.get(1).unwrap().as_str();
+                let mut thread = None;
+                let mut content = message.to_string();
+
+                if let Some((token, parsed_message)) = IRC::parse_reply_command(message) {
+                    if let Some(thread_ref) =
+                        self.resolve_reply_token(&channel, Some(&nickname), &token)
+                    {
+                        thread = Some(thread_ref);
+                        content = parsed_message;
+                    } else {
+                        self.send_reply_token_usage_notice(client, &channel).await;
+                        return Ok(());
+                    }
+                }
+
                 let message = Message::Action {
                     sender: self.transport_id,
                     pipo_id,
                     transport: TRANSPORT_NAME.to_string(),
                     username: nickname.clone(),
                     avatar_url: Some(avatar_url),
-                    thread: None,
-                    message: Some(message.to_string()),
+                    thread,
+                    message: Some(content),
                     attachments: None,
                     is_edit: false,
                     irc_flag: false,
@@ -532,14 +1250,29 @@ impl IRC {
                     Err(e) => Err(anyhow!("Couldn't send message: {:#}", e)),
                 };
             } else {
+                let mut thread = None;
+                let mut content = message.to_string();
+
+                if let Some((token, parsed_message)) = IRC::parse_reply_command(&message) {
+                    if let Some(thread_ref) =
+                        self.resolve_reply_token(&channel, Some(&nickname), &token)
+                    {
+                        thread = Some(thread_ref);
+                        content = parsed_message;
+                    } else {
+                        self.send_reply_token_usage_notice(client, &channel).await;
+                        return Ok(());
+                    }
+                }
+
                 let message = Message::Text {
                     sender: self.transport_id,
                     pipo_id,
                     transport: TRANSPORT_NAME.to_string(),
                     username: nickname.clone(),
                     avatar_url: Some(avatar_url),
-                    thread: None,
-                    message: Some(message.to_string()),
+                    thread,
+                    message: Some(content),
                     attachments: None,
                     is_edit: false,
                     irc_flag: false,
@@ -583,17 +1316,142 @@ impl IRC {
         Ok(ret)
     }
 
+    fn generated_irc_message_id(pipo_id: i64) -> String {
+        format!("pipo-{}", pipo_id)
+    }
+
+    async fn ensure_ircid_for_pipo_id(&self, pipo_id: i64) -> Option<String> {
+        if let Some(ircid) = self.select_ircid_from_messages(pipo_id).await {
+            return Some(ircid);
+        }
+
+        let generated = IRC::generated_irc_message_id(pipo_id);
+        if self
+            .update_messages_ircid(pipo_id, Some(generated.clone()))
+            .await
+            .is_ok()
+        {
+            Some(generated)
+        } else {
+            None
+        }
+    }
+
+    async fn update_messages_ircid(
+        &self,
+        pipo_id: i64,
+        irc_message_id: Option<String>,
+    ) -> anyhow::Result<()> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<usize> {
+            Ok(conn.execute(
+                "UPDATE messages SET ircid = ?2 WHERE id = ?1",
+                params![pipo_id, irc_message_id],
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))?;
+
+        Ok(())
+    }
+
+    async fn select_ircid_from_messages(&self, pipo_id: i64) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT ircid FROM messages WHERE id = ?1",
+                params![pipo_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
+    async fn select_ircid_by_slackid(&self, slackid: String) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT ircid FROM messages WHERE slackid = ?1",
+                params![slackid],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
+    async fn select_ircid_by_discordid(&self, discordid: u64) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT ircid FROM messages WHERE discordid = ?1",
+                params![discordid],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
+    async fn select_ircid_by_ircid(&self, ircid: String) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT ircid FROM messages WHERE ircid = ?1",
+                params![ircid],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
+    async fn select_slackid_from_messages(&self, pipo_id: i64) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT slackid FROM messages WHERE id = ?1",
+                params![pipo_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
     async fn handle_notice(
         &self,
         nickname: String,
         channel: String,
         message: String,
+        irc_message_id: Option<String>,
     ) -> anyhow::Result<()> {
         if let Some(sender) = self.channels.get(&channel) {
             lazy_static! {
                 static ref RE: Regex = Regex::new("^\x01ACTION (.*)\x01\r?$").unwrap();
             }
             let pipo_id = self.insert_into_messages_table().await?;
+            if let Some(irc_message_id) = irc_message_id {
+                self.update_messages_ircid(pipo_id, Some(irc_message_id))
+                    .await?;
+            }
 
             let avatar_url = self.get_avatar_url(&nickname).await;
 
@@ -635,6 +1493,16 @@ impl IRC {
             }
         } else {
             return Err(anyhow!("Could not get sender for channel {}", channel));
+        }
+    }
+}
+
+impl Default for ThreadPresentation {
+    fn default() -> Self {
+        Self {
+            reply_target: None,
+            plaintext_prefix: None,
+            mode_used: "none",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod rachni;
 pub mod slack;
 
 use crate::discord::Discord;
-use crate::irc::IRC;
+use crate::irc::{IRC, ThreadContextRepeat, ThreadFallbackStyle, ThreadPresentationMode};
 use crate::mumble::Mumble;
 use crate::rachni::Rachni;
 use crate::slack::Slack;
@@ -35,7 +35,7 @@ enum Message {
         transport: String,
         username: String,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
         is_edit: bool,
@@ -73,7 +73,7 @@ enum Message {
         remove: bool,
         username: Option<String>,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
     },
     Text {
         sender: usize,
@@ -81,12 +81,21 @@ enum Message {
         transport: String,
         username: String,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
         is_edit: bool,
         irc_flag: bool,
     },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ThreadRef {
+    origin_transport: String,
+    thread_root_id: Option<String>,
+    reply_target_id: Option<u64>,
+    root_author: Option<String>,
+    root_excerpt: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -205,6 +214,16 @@ enum ConfigTransport {
         use_tls: bool,
         img_root: Arc<String>,
         channel_mapping: HashMap<Arc<String>, Arc<String>>,
+        #[serde(default)]
+        thread_presentation_mode: ThreadPresentationMode,
+        #[serde(default)]
+        thread_fallback_style: ThreadFallbackStyle,
+        #[serde(default)]
+        thread_context_repeat: ThreadContextRepeat,
+        #[serde(default = "default_thread_excerpt_len")]
+        thread_excerpt_len: usize,
+        #[serde(default = "default_show_thread_root_marker")]
+        show_thread_root_marker: bool,
     },
     Discord {
         token: Arc<String>,
@@ -242,6 +261,14 @@ enum ConfigTransport {
 struct ParsedConfig {
     buses: Vec<ConfigBus>,
     transports: Vec<ConfigTransport>,
+}
+
+fn default_thread_excerpt_len() -> usize {
+    120
+}
+
+fn default_show_thread_root_marker() -> bool {
+    true
 }
 
 pub async fn inner_main() -> anyhow::Result<()> {
@@ -286,6 +313,7 @@ pub async fn inner_main() -> anyhow::Result<()> {
                                            id        INTEGER PRIMARY KEY,
                                            slackid   TEXT,
                                            discordid INTEGER,
+                                           ircid     TEXT,
                                            modtime   DEFAULT 
                                              (strftime('%Y-%m-%d %H:%M:%S:%s',
                                                        'now', 
@@ -303,6 +331,15 @@ pub async fn inner_main() -> anyhow::Result<()> {
                         )?;
                     }
                     Err(e) => return Err(anyhow!(e)),
+                }
+
+                let ircid_exists = conn
+                    .prepare("PRAGMA table_info(messages)")?
+                    .query_map([], |row| row.get::<usize, String>(1))?
+                    .filter_map(Result::ok)
+                    .any(|column| column == "ircid");
+                if !ircid_exists {
+                    conn.execute("ALTER TABLE messages ADD COLUMN ircid TEXT", [])?;
                 }
 
                 Ok(
@@ -374,6 +411,11 @@ pub async fn inner_main() -> anyhow::Result<()> {
                 use_tls,
                 img_root,
                 channel_mapping,
+                thread_presentation_mode,
+                thread_fallback_style,
+                thread_context_repeat,
+                thread_excerpt_len,
+                show_thread_root_marker,
             } => {
                 // tokio::spawn maybe?
                 let mut instance = IRC::new(
@@ -385,6 +427,11 @@ pub async fn inner_main() -> anyhow::Result<()> {
                     *use_tls,
                     &img_root,
                     &channel_mapping,
+                    *thread_presentation_mode,
+                    *thread_fallback_style,
+                    *thread_context_repeat,
+                    *thread_excerpt_len,
+                    *show_thread_root_marker,
                     transport_id,
                 )
                 .await?;

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -23,7 +23,7 @@ use tokio::{net::TcpStream, sync::broadcast};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt, StreamMap};
 use tokio_tungstenite::*;
 
-use crate::Message;
+use crate::{Message, ThreadRef};
 
 pub mod objects;
 use objects::{Message as SlackMessage, *};
@@ -44,7 +44,14 @@ pub(crate) struct Slack {
     channel_map: HashMap<String, String>,
     id_map: HashMap<String, String>,
     users: HashMap<String, User>,
+    thread_metadata_cache: HashMap<String, SlackThreadMetadata>,
     seen_event_ids: VecDeque<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SlackThreadMetadata {
+    root_author: Option<String>,
+    root_excerpt: Option<String>,
 }
 
 struct WebSocket {
@@ -93,6 +100,7 @@ impl Slack {
             channel_map: HashMap::new(),
             id_map: HashMap::new(),
             users: HashMap::new(),
+            thread_metadata_cache: HashMap::new(),
             seen_event_ids: VecDeque::with_capacity(50),
         })
     }
@@ -430,7 +438,7 @@ impl Slack {
         emoji: String,
         _username: Option<String>,
         _avatar_url: Option<String>,
-        _thread: Option<(Option<String>, Option<u64>)>,
+        _thread: Option<ThreadRef>,
     ) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
         let channel = match self.channel_map.get(channel) {
@@ -619,13 +627,13 @@ impl Slack {
         transport: String,
         username: String,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
         is_edit: bool,
     ) -> anyhow::Result<()> {
         let thread_ts = match thread {
-            Some((s, _)) => s,
+            Some(thread_ref) => thread_ref.thread_root_id,
             None => None,
         };
         let message = message.map(|s| format!("_{}_", s));
@@ -803,15 +811,15 @@ impl Slack {
         transport: String,
         username: String,
         avatar_url: Option<String>,
-        thread: Option<(Option<String>, Option<u64>)>,
+        thread: Option<ThreadRef>,
         message: Option<String>,
         attachments: Option<Vec<crate::Attachment>>,
         is_edit: bool,
     ) -> anyhow::Result<()> {
         let thread_ts = match thread {
-            Some((_, d)) => match d {
-                Some(d) => self.get_slackid_from_discordid(d).await?,
-                None => None,
+            Some(thread_ref) => match thread_ref.reply_target_id {
+                Some(reply_target_id) => self.get_slackid_from_discordid(reply_target_id).await?,
+                None => thread_ref.thread_root_id,
             },
             None => None,
         };
@@ -923,7 +931,7 @@ impl Slack {
         emoji: String,
         _username: Option<String>,
         _avatar_url: Option<String>,
-        _thread: Option<(Option<String>, Option<u64>)>,
+        _thread: Option<ThreadRef>,
     ) -> anyhow::Result<()> {
         let mut headers = HeaderMap::new();
         let channel = match self.channel_map.get(channel) {
@@ -1355,16 +1363,7 @@ impl Slack {
                     None => false,
                 };
                 let channel = match channel {
-                    Some(channel) => match self.id_map.get(&channel) {
-                        Some(channel) => channel.to_owned(),
-                        None => {
-                            return Err(anyhow!(
-                                "Channel name not found \
-                            for channel id: {}",
-                                channel
-                            ))
-                        }
-                    },
+                    Some(channel) => channel,
                     None => {
                         return Err(anyhow!(
                             "Message does not contain a \
@@ -1372,6 +1371,7 @@ impl Slack {
                         ))
                     }
                 };
+                let (channel_name, channel_id) = self.resolve_channel_name_and_id(channel)?;
 
                 let rich_text = if let Some(blocks) = blocks {
                     let mut rich_text = String::new();
@@ -1408,7 +1408,8 @@ impl Slack {
                                 .handle_bot_message(
                                     ts,
                                     thread_ts,
-                                    &channel,
+                                    &channel_name,
+                                    &channel_id,
                                     rich_text,
                                     attachments,
                                     hidden,
@@ -1421,7 +1422,8 @@ impl Slack {
                                 .handle_file_share(
                                     ts,
                                     thread_ts,
-                                    &channel,
+                                    &channel_name,
+                                    &channel_id,
                                     user,
                                     rich_text,
                                     files,
@@ -1432,7 +1434,14 @@ impl Slack {
                         }
                         "me_message" => {
                             return self
-                                .handle_me_message(ts, &channel, user, rich_text, is_edit, irc_flag)
+                                .handle_me_message(
+                                    ts,
+                                    &channel_name,
+                                    user,
+                                    rich_text,
+                                    is_edit,
+                                    irc_flag,
+                                )
                                 .await
                         }
                         "message_changed" => {
@@ -1440,7 +1449,7 @@ impl Slack {
                                 .handle_message_changed(
                                     ts,
                                     thread_ts,
-                                    &channel,
+                                    &channel_name,
                                     message,
                                     prev_message,
                                     hidden,
@@ -1448,14 +1457,15 @@ impl Slack {
                                 .await
                         }
                         "message_deleted" => {
-                            return self.handle_message_deleted(deleted_ts, &channel).await
+                            return self.handle_message_deleted(deleted_ts, &channel_name).await
                         }
                         _ => {
                             return self
                                 .handle_message(
                                     ts,
                                     thread_ts,
-                                    &channel,
+                                    &channel_name,
+                                    &channel_id,
                                     user,
                                     rich_text,
                                     attachments,
@@ -1470,7 +1480,8 @@ impl Slack {
                             .handle_message(
                                 ts,
                                 thread_ts,
-                                &channel,
+                                &channel_name,
+                                &channel_id,
                                 user,
                                 rich_text,
                                 attachments,
@@ -1515,23 +1526,134 @@ impl Slack {
         }
     }
 
+    fn resolve_channel_name_and_id(&self, channel_id: String) -> anyhow::Result<(String, String)> {
+        let channel_name = match self.id_map.get(&channel_id) {
+            Some(channel_name) => channel_name.to_owned(),
+            None => {
+                return Err(anyhow!(
+                    "Channel name not found for channel id: {}",
+                    channel_id
+                ))
+            }
+        };
+
+        Ok((channel_name, channel_id))
+    }
+
+    fn build_thread_excerpt(message: Option<&str>) -> Option<String> {
+        let message = message?.trim();
+        if message.is_empty() {
+            return None;
+        }
+
+        let excerpt = message.chars().take(120).collect::<String>();
+        if message.chars().count() > 120 {
+            Some(format!("{}…", excerpt))
+        } else {
+            Some(excerpt)
+        }
+    }
+
+    fn get_username_from_cache(&self, user_id: &str) -> Option<String> {
+        self.users
+            .values()
+            .find(|user| user.id.as_deref() == Some(user_id))
+            .and_then(|user| Slack::get_username(user).ok())
+    }
+
+    async fn fetch_thread_root_metadata(
+        &mut self,
+        channel_id: &str,
+        thread_root_id: &str,
+    ) -> anyhow::Result<SlackThreadMetadata> {
+        let root_message = self
+            .get_message(channel_id, &Timestamp(thread_root_id.to_string()))
+            .await?;
+        let root_user = root_message.user.clone();
+        let root_text = root_message.text.clone();
+        let root_author = match root_user {
+            Some(user_id) => match self.get_username_from_cache(&user_id) {
+                Some(name) => Some(name),
+                None => {
+                    let user = self.get_user_info(&user_id).await?;
+                    Some(Slack::get_username(&user)?)
+                }
+            },
+            None => None,
+        };
+
+        Ok(SlackThreadMetadata {
+            root_author,
+            root_excerpt: Slack::build_thread_excerpt(root_text.as_deref()),
+        })
+    }
+
+    async fn build_slack_thread_ref(
+        &mut self,
+        thread_ts: Option<String>,
+        channel_id: &str,
+        message_ts: Option<&str>,
+        local_author: Option<&str>,
+        local_message: Option<&str>,
+    ) -> anyhow::Result<Option<ThreadRef>> {
+        let Some(thread_root_id) = thread_ts else {
+            return Ok(None);
+        };
+
+        match self.select_id_from_messages(&thread_root_id).await {
+            Some(_) => {}
+            None => {
+                self.insert_into_messages_table(&thread_root_id).await?;
+            }
+        }
+
+        let metadata = if message_ts == Some(thread_root_id.as_str()) {
+            SlackThreadMetadata {
+                root_author: local_author.map(String::from),
+                root_excerpt: Slack::build_thread_excerpt(local_message),
+            }
+        } else if let Some(metadata) = self.thread_metadata_cache.get(&thread_root_id) {
+            metadata.clone()
+        } else {
+            self.fetch_thread_root_metadata(channel_id, &thread_root_id)
+                .await?
+        };
+
+        self.thread_metadata_cache
+            .insert(thread_root_id.clone(), metadata.clone());
+
+        Ok(Some(ThreadRef {
+            origin_transport: TRANSPORT_NAME.to_string(),
+            reply_target_id: self
+                .select_discordid_from_messages(thread_root_id.clone())
+                .await?,
+            thread_root_id: Some(thread_root_id),
+            root_author: metadata.root_author,
+            root_excerpt: metadata.root_excerpt,
+            ..Default::default()
+        }))
+    }
+
     async fn handle_bot_message(
         &mut self,
         ts: Option<String>,
         thread_ts: Option<String>,
-        channel: &str,
+        channel_name: &str,
+        channel_id: &str,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
         _hidden: bool,
         is_edit: bool,
     ) -> anyhow::Result<()> {
-        let _thread = match thread_ts {
-            Some(ts) => Some((
-                Some(ts.clone()),
-                self.select_discordid_from_messages(ts).await?,
-            )),
-            None => None,
-        };
+        let _thread = self
+            .build_slack_thread_ref(
+                thread_ts,
+                channel_id,
+                ts.as_deref(),
+                None,
+                message.as_deref(),
+            )
+            .await?;
         let pipo_id = match ts {
             Some(ts) => match self.select_id_from_messages(&ts).await {
                 Some(id) => id,
@@ -1553,14 +1675,15 @@ impl Slack {
             is_edit,
         };
 
-        return self.send_message(channel, message).await;
+        return self.send_message(channel_name, message).await;
     }
 
     async fn handle_file_share(
         &mut self,
         ts: Option<String>,
         thread_ts: Option<String>,
-        channel: &str,
+        channel_name: &str,
+        channel_id: &str,
         user: Option<String>,
         message: Option<String>,
         files: Option<Vec<File>>,
@@ -1592,7 +1715,8 @@ impl Slack {
         self.handle_message(
             ts,
             thread_ts,
-            channel,
+            channel_name,
+            channel_id,
             user,
             message,
             attachments,
@@ -1931,7 +2055,8 @@ impl Slack {
         &mut self,
         ts: Option<String>,
         thread_ts: Option<String>,
-        channel: &str,
+        channel_name: &str,
+        channel_id: &str,
         user: Option<String>,
         message: Option<String>,
         attachments: Option<Vec<Attachment>>,
@@ -1940,10 +2065,6 @@ impl Slack {
     ) -> anyhow::Result<()> {
         let has_message = message.is_some();
         let has_attachments = attachments.is_some();
-        let thread = match thread_ts {
-            Some(ts) => Some((Some(ts.clone()), None)),
-            None => None,
-        };
         let ts = ts.ok_or_else(|| anyhow!("Message has no timestamp."))?;
         let pipo_id = match self.select_id_from_messages(&ts).await {
             Some(id) => id,
@@ -1959,6 +2080,15 @@ impl Slack {
             .get_user_info(&user.ok_or_else(|| anyhow!("No user ID in message."))?)
             .await?;
         let username = Slack::get_username(&user)?;
+        let thread = self
+            .build_slack_thread_ref(
+                thread_ts,
+                channel_id,
+                Some(ts.as_str()),
+                Some(username.as_str()),
+                message.as_deref(),
+            )
+            .await?;
         let avatar_url = Slack::get_avatar_url_for_user(&user)?;
         let attachments = match attachments {
             Some(attachments) => Some(self.handle_attachments(attachments).await),
@@ -1966,6 +2096,14 @@ impl Slack {
         };
 
         if has_message || has_attachments {
+            self.thread_metadata_cache.insert(
+                ts.clone(),
+                SlackThreadMetadata {
+                    root_author: Some(username.clone()),
+                    root_excerpt: Slack::build_thread_excerpt(message.as_deref()),
+                },
+            );
+
             let message = Message::Text {
                 pipo_id,
                 sender: self.transport_id,
@@ -1979,12 +2117,12 @@ impl Slack {
                 irc_flag,
             };
 
-            return self.send_message(channel, message).await;
+            return self.send_message(channel_name, message).await;
         } else {
             return Err(anyhow!(
                 "Message from {} on channel {} has no content",
                 username,
-                channel
+                channel_name
             ));
         }
     }
@@ -2175,6 +2313,11 @@ impl Slack {
         attachments: Vec<crate::Attachment>,
     ) -> Vec<Attachment> {
         let mut ret = Vec::new();
+        let channel_id = self
+            .channel_map
+            .get(channel)
+            .map(String::as_str)
+            .unwrap_or(channel);
 
         for attachment in attachments {
             let ts = match attachment.pipo_id {
@@ -2195,7 +2338,7 @@ impl Slack {
             // (*) blocks
             // (*) maybe subtype?
             let message = match ts {
-                Some(ref ts) => self.get_message(channel, ts).await.ok(),
+                Some(ref ts) => self.get_message(channel_id, ts).await.ok(),
                 None => None,
             };
 
@@ -2555,7 +2698,8 @@ impl Slack {
             format!("Bearer {}", self.bot_token).parse()?,
         );
 
-        let url = reqwest::Url::parse_with_params("https://slack.com/api/users.info", &[("user", user)])?;
+        let url =
+            reqwest::Url::parse_with_params("https://slack.com/api/users.info", &[("user", user)])?;
 
         let response = self
             .http


### PR DESCRIPTION
* Introduce ThreadRef metadata for threaded messages (#242)

* Introduce ThreadRef metadata for threaded messages

* Trigger CI

* Remove unnecessary mutex around IRC capability state (#245)

* Add IRC message-id persistence and reply target lookup (#247)

* Add IRC thread-context fallback prefixes for outbound messages (#250)

* Enrich Slack thread refs with root message context (#251)

* Add configurable IRC thread presentation modes (#253)

* Split Slack inbound channel name vs channel ID (#275)

* Improve IRC thread fallback with tokenized context (#280)

* Add IRC token-based threaded reply parsing (#282)

* Add IRC thread discovery and help commands (#283)