### PR TITLE
Update IRC plaintext thread-root announcement to include token

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,7 +50,7 @@ For IRC transports, threaded message presentation can be tuned per transport ent
   - =always=: always emit expanded context lines.
   - =never=: never emit expanded context lines; always use compact token prefixes.
 - =thread_excerpt_len= (default =120=): max character count used for plaintext thread root excerpts.
-- =show_thread_root_marker= (default =true=): when plaintext mode is used for the root post itself, include the =[thread]= marker.
+- =show_thread_root_marker= (default =true=): when plaintext mode is used for the root post itself, emit a thread-start announcement such as =started a new thread: … (reply: >>K7F2)=.
 
 Migration behavior:
 - Existing configs continue to work without changes.

--- a/docs/irc-threading-modes.md
+++ b/docs/irc-threading-modes.md
@@ -11,7 +11,7 @@ Pipo supports configurable IRC thread presentation for each IRC transport block.
 - `thread_excerpt_len` (default: `120`)
   - Max character length for plaintext root excerpts in `↪ reply to ...` prefixes.
 - `show_thread_root_marker` (default: `true`)
-  - Controls whether root messages include `[thread]` in plaintext mode.
+  - Controls whether root messages include a plaintext thread-start announcement, e.g. `started a new thread: … (reply: >>K7F2)`.
 
 ## Migration and operator guidance
 

--- a/src/irc.rs
+++ b/src/irc.rs
@@ -939,8 +939,12 @@ impl IRC {
                 IRC::sanitize_thread_context_text(thread_ref.root_author.as_deref())
                     .filter(|author| !author.is_empty())
             })?;
+        let thread_token = IRC::thread_token(thread_ref);
 
-        Some(format!("replied to a thread: {}", thread_name))
+        Some(format!(
+            "started a new thread: {} (reply: >>{})",
+            thread_name, thread_token
+        ))
     }
 
     fn outbound_thread_fallback_prefix(


### PR DESCRIPTION
### Motivation
- Replace the old `[thread]` root marker with a readable announcement that reuses existing root metadata and the `IRC::thread_token` so IRC plaintext roots read like `started a new thread: $THREAD_NAME (reply: >>TOKEN)`.

### Description
- Change `src/irc.rs::thread_announcement_line` to compute `IRC::thread_token(thread_ref)` and return `started a new thread: {} (reply: >>{})` using the existing `root_excerpt`/`root_author` fallbacks.
- Keep the existing root-detection via `is_thread_root_message` and the Slack-side `build_slack_thread_ref` behavior untouched.
- Update `README.org` and `docs/irc-threading-modes.md` to document the new plaintext root announcement format and adjust `show_thread_root_marker` wording.

### Testing
- Ran `rustfmt --edition 2021 src/irc.rs` which completed successfully.
- Ran `cargo fmt --all` which failed in this environment due to missing generated protobuf file `src/protos/Mumble.rs` required for module resolution.
- Started `cargo test`, which began compiling dependencies but did not complete during the run, so no final test result was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7f6ff4908331a5a08afba1018099)