### PR TITLE
chore(lockfile): bump aws-lc-rs to 1.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
### Motivation
- Pin the transitive crypto crate `aws-lc-rs` to `1.16.2` so `aws-lc-sys` advances to the `0.39.x` series and TLS-related transitive dependencies are kept up to date.

### Description
- Ran `cargo update -p aws-lc-rs --precise 1.16.2` and updated `Cargo.lock` so it now lists `aws-lc-rs = 1.16.2` and `aws-lc-sys = 0.39.1`.

### Testing
- Verified the reverse dependency chain with `cargo tree -i aws-lc-sys --locked` and ran `cargo build --locked` and `cargo test --locked`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7073caa0c8331b8bc343371b4e37f)