### PR TITLE
chore: update rustls 0.23 dependency stack to rustls-webpki 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1545,7 +1545,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
- "rustls 0.21.12",
+ "rustls",
  "serde",
  "serde_json",
  "serenity",
@@ -1744,7 +1744,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -1765,7 +1765,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1933,7 +1933,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper",
@@ -2019,18 +2019,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -2039,7 +2027,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -2077,10 +2065,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2095,19 +2083,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2144,16 +2122,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "secrecy"
@@ -2599,7 +2567,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ nix = "0.31"
 #parser = { path = "./parser" }
 protobuf = ">=3.7.2"
 regex = "1.11"
-reqwest = { version = "0.13", features = ["multipart"] }
+reqwest = { version = "0.13.2", features = ["multipart"] }
 rusqlite = "0.28"
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls = "0.23"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serenity = { version = "0.12", default-features = false, features = ["chrono", "client", "gateway", "native_tls_backend", "model"] }
 sha2 = "0.10"
 tokio = { version = "1.43", features = ["full"] }
-tokio-rustls = "0.26"
+tokio-rustls = "0.26.4"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
 webpki-roots = "1.0"


### PR DESCRIPTION
### Motivation
- Remediate dependency resolver pin that selected `rustls-webpki 0.103.9` by moving the project to a `rustls 0.23` stack that resolves to `rustls-webpki >= 0.103.10` to address the CWE-299 concern.

### Description
- Bumped `reqwest` to `0.13.2`, set `rustls` to `0.23`, and pinned `tokio-rustls` to `0.26.4` in `Cargo.toml` so the manifest targets the rustls 0.23 stack.
- Performed a targeted lockfile update with `cargo update -p rustls-webpki@0.103.9 --precise 0.103.10` and regenerated `Cargo.lock`, which removed legacy `rustls 0.21`/`rustls-webpki 0.101` entries and added `rustls-webpki 0.103.10`.
- Confirmed transitive alignment so `hyper-rustls 0.27.7` and `reqwest 0.13.2` now resolve through the `rustls 0.23` stack in the updated lockfile.

### Testing
- Ran `cargo update -p rustls-webpki@0.103.9 --precise 0.103.10`, which completed successfully.
- Verified the lockfile with `rg -n 'name = "rustls-webpki"|version = "0.103.9"' Cargo.lock`, which showed `rustls-webpki` at `0.103.10` and no `0.103.9` entries.
- Ran `cargo tree -i rustls-webpki --locked` to inspect the dependency graph and confirmed only non-affected `rustls-webpki` versions are present.
- Executed `cargo check --locked`, which completed successfully (build finished with warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c712c78f0c833196e7765dce30386b)