### PR TITLE
Update rand to patched 0.9.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2778,7 +2778,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
 ]


### PR DESCRIPTION
### Motivation
- Ensure the dependency graph does not contain unpatched `rand` releases and address the reported unsoundness by moving the `rand` 0.9 lock entry into a patched release range.

### Description
- Bumped the locked `rand` entry from `0.9.2` to `0.9.3` in `Cargo.lock`, updating the checksum and transitive references so dependent packages (e.g. `quinn-proto` and `tungstenite`) resolve to the patched `0.9.3`, while the existing `rand 0.8.6` entry remains unchanged.

### Testing
- Ran `cargo tree --locked --package pipo | rg 'rand v'` to verify the graph references patched `rand` versions and ran `cargo test --locked`, and the test suite completed successfully (all unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f9678ff883318395b2a0b240794c)