### PR TITLE
Add Matrix transport for bridging Matrix rooms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as_variant"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+
+[[package]]
+name = "assign"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +125,58 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -893,6 +957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +976,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1141,7 +1212,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -1216,6 +1287,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "js_int"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f95470b270ce8b8950207715d71aa8e153c0d44c6684d59397ed4949160a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "js_option"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1370,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -1528,6 +1623,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "axum",
  "bytes",
  "chrono",
  "deadpool-sqlite",
@@ -1543,6 +1639,7 @@ dependencies = [
  "protoc-bin-vendored",
  "regex",
  "reqwest",
+ "ruma",
  "rusqlite",
  "rustls",
  "serde",
@@ -1594,6 +1691,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1935,6 +2041,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
@@ -1968,6 +2076,96 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ruma"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4fe5bfacdb0e95e733da3b6c37d98edf46447a4a8e8dea824e0da266d8ad59"
+dependencies = [
+ "assign",
+ "js_int",
+ "js_option",
+ "ruma-common",
+ "ruma-events",
+ "web-time",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3b4f00112791b490acce57df1ce3eb3f88899b045bebcff8a29f75369640cc"
+dependencies = [
+ "as_variant",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "indexmap",
+ "js_int",
+ "percent-encoding",
+ "regex",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "web-time",
+ "wildmatch",
+ "zeroize",
+]
+
+[[package]]
+name = "ruma-events"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85d2f90830fc131691349b96a69ff53444eb6c3e8dc7869c77961b43cfaf3344"
+dependencies = [
+ "as_variant",
+ "indexmap",
+ "js_int",
+ "js_option",
+ "ruma-common",
+ "ruma-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
+ "wildmatch",
+ "zeroize",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6cff00317675f487c4e7ccfb18875a14c5a14867b51d13f2a826053f03c432"
+dependencies = [
+ "js_int",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cfb39eaa9b9fd389126ff941e060b496add5cbbfef559d80c46e571dda459c"
+dependencies = [
+ "as_variant",
+ "cfg-if",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation",
+ "serde",
+ "syn",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2099,6 +2297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2409,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0346d7a342ab90f405cfc08f25d15075f944f42fcabbc5eac923829fa6d228"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,11 +2435,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2630,9 +2879,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2645,6 +2907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,9 +2923,30 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2670,6 +2962,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3091,6 +3384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3630,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Noah Obert <nemored@gmail.com"]
 [dependencies]
 anyhow = "1.0"
 async-recursion = "1.1"
+axum = "0.8"
 bytes = "1.11"
 chrono = "0.4"
 deadpool-sqlite = "0.5"
@@ -24,7 +25,8 @@ nix = "0.31"
 #parser = { path = "./parser" }
 protobuf = ">=3.7.2"
 regex = "1.11"
-reqwest = { version = "0.13.2", features = ["multipart"] }
+reqwest = { version = "0.13.2", features = ["multipart", "json"] }
+ruma = { version = "0.16", features = ["events"] }
 rusqlite = "0.28"
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/README.org
+++ b/README.org
@@ -22,6 +22,13 @@ cargo run
 *** TODO Improve translation of Slack formatting to Markdown formatting
 
 
+** Matrix transport
+Pipo can bridge Matrix by running as a single Matrix Application Service whose
+user namespace spans every other bridged service (ghost users like
+=@pipo_irc_alice=, =@pipo_slack_bob=). See [[file:docs/matrix-transport.md][docs/matrix-transport.md]] for the
+registration file, config block, and current limitations.
+
+
 ** Protobuf generation contract
 - Source proto path: =protos/Mumble.proto=
 - Generated output path: =src/protos=

--- a/docs/matrix-transport.md
+++ b/docs/matrix-transport.md
@@ -1,0 +1,99 @@
+# Matrix transport
+
+PIPO bridges Matrix by acting as a single Matrix **Application Service**
+(appservice). Because one bridge can register a user-namespace regex that spans
+every service PIPO connects to, remote senders are puppeted as distinct "ghost"
+Matrix users (`@pipo_irc_alice`, `@pipo_slack_bob`, ...) rather than relayed
+through a single bot account.
+
+- **Inbound** events are pushed to PIPO by the homeserver over HTTP
+  (`PUT /_matrix/app/v1/transactions/{txnId}`); PIPO hosts that listener itself.
+- **Outbound** messages are sent through the Client-Server API, masquerading as
+  the relevant ghost via the appservice `?user_id=` parameter with the
+  `as_token` as the access token.
+
+Event content is built and parsed with the community-maintained
+[`ruma`](https://github.com/ruma/ruma) types; PIPO does not depend on
+`matrix-sdk` (its client-session/sync layer is unused by an appservice, and it
+cannot perform the `?user_id=` masquerade).
+
+## v1 scope
+
+Bridged in **both directions**: plain text messages, edits (`m.replace`),
+deletes (redactions), and reactions (`m.reaction`).
+
+Deferred: attachments/media and threads (the code marks where they hook in),
+and **encrypted rooms** — bridged Matrix rooms must have encryption disabled.
+
+## 1. Registration file (operator-provided)
+
+PIPO does not generate this. Write it, register it with your homeserver, and
+copy the two tokens into PIPO's config. Example `pipo-registration.yaml`:
+
+```yaml
+id: pipo
+url: "http://127.0.0.1:8090"        # must match listen_addr and be reachable by the homeserver
+as_token: "REPLACE_WITH_A_LONG_RANDOM_STRING"
+hs_token: "REPLACE_WITH_A_DIFFERENT_LONG_RANDOM_STRING"
+sender_localpart: "pipo"            # -> @pipo:example.org
+rate_limited: false
+namespaces:
+  users:
+    - exclusive: true
+      regex: "@pipo_.*"             # ONE regex spanning every bridged service
+  aliases: []
+  rooms: []
+```
+
+On Synapse, reference it from `homeserver.yaml`:
+
+```yaml
+app_service_config_files:
+  - /path/to/pipo-registration.yaml
+```
+
+The single `@pipo_.*` namespace intentionally covers `@pipo_irc_*`,
+`@pipo_slack_*`, `@pipo_discord_*`, etc. — the whole point of running PIPO as one
+multi-service bridge instead of one bridge per service.
+
+## 2. PIPO config block
+
+Add a transport of type `Matrix` to your PIPO config. Note that the homeserver
+is given as a host (and optional port) plus `use_tls`, **not** a full URL —
+PIPO's config parser strips `//` as a comment, so a `https://` value cannot be
+written directly.
+
+```json
+{
+  "transport": "Matrix",
+  "homeserver": "matrix.example.org",
+  "use_tls": true,
+  "server_name": "example.org",
+  "as_token": "REPLACE_WITH_A_LONG_RANDOM_STRING",
+  "hs_token": "REPLACE_WITH_A_DIFFERENT_LONG_RANDOM_STRING",
+  "sender_localpart": "pipo",
+  "ghost_prefix": "pipo_",
+  "listen_addr": "0.0.0.0:8090",
+  "channel_mapping": { "!abcdef:example.org": "bus1" }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `homeserver` | Homeserver client-server API host, optionally `host:port`. |
+| `use_tls` | `true` for `https`, `false` for `http`. |
+| `server_name` | The `:domain` half of user/room IDs, e.g. `example.org`. |
+| `as_token` / `hs_token` | Must match the registration file exactly. |
+| `sender_localpart` | Must equal the registration's `sender_localpart`. |
+| `ghost_prefix` | Must be the literal prefix of the users namespace regex (`pipo_` for `@pipo_.*`). |
+| `listen_addr` | Address the inbound appservice listener binds to; the registration `url` must reach it. |
+| `channel_mapping` | Matrix room ID → PIPO bus id. |
+
+## Operational notes
+
+- The appservice sender user (`@pipo:example.org`) performs redactions for
+  bridged deletes, so it should hold a **moderator** power level in bridged
+  rooms.
+- Ghost users auto-join their mapped rooms. In invite-only rooms the sender user
+  must invite the ghost first (not yet automated).
+- Bridged rooms must be **unencrypted** in this version.

--- a/docs/pipo-registration.example.yaml
+++ b/docs/pipo-registration.example.yaml
@@ -1,0 +1,21 @@
+# Example Matrix appservice registration for PIPO.
+#
+# Register this with your homeserver (on Synapse, list it under
+# `app_service_config_files` in homeserver.yaml) and copy `as_token` /
+# `hs_token` into PIPO's Matrix transport config. See docs/matrix-transport.md.
+#
+# Replace the two tokens with long random strings and make them different from
+# each other.
+id: pipo
+url: "http://127.0.0.1:8090" # must match the transport's listen_addr and be reachable by the homeserver
+as_token: "REPLACE_WITH_A_LONG_RANDOM_STRING"
+hs_token: "REPLACE_WITH_A_DIFFERENT_LONG_RANDOM_STRING"
+sender_localpart: "pipo"
+rate_limited: false
+namespaces:
+  users:
+    # A single exclusive namespace spanning every service PIPO bridges.
+    - exclusive: true
+      regex: "@pipo_.*"
+  aliases: []
+  rooms: []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use tokio::{fs::File, io::AsyncReadExt, sync::broadcast};
 
 mod discord;
 mod irc;
+mod matrix;
 mod mumble;
 pub(crate) mod protos;
 mod rachni;
@@ -21,6 +22,7 @@ pub mod slack;
 
 use crate::discord::Discord;
 use crate::irc::{IRC, ThreadContextRepeat, ThreadFallbackStyle, ThreadPresentationMode};
+use crate::matrix::Matrix;
 use crate::mumble::Mumble;
 use crate::rachni::Rachni;
 use crate::slack::Slack;
@@ -255,6 +257,34 @@ enum ConfigTransport {
         interval: u64,
         buses: Arc<Vec<String>>,
     },
+    Matrix {
+        // Host (or host:port) of the homeserver's client-server API, e.g.
+        // "matrix.example.org". The scheme is derived from use_tls; it is not
+        // written here because the config parser strips "//" as a comment.
+        homeserver: Arc<String>,
+        // Whether to reach the homeserver over HTTPS.
+        use_tls: bool,
+        // The homeserver's domain, i.e. the ":server_name" half of user
+        // and room IDs, e.g. "example.org".
+        server_name: Arc<String>,
+        // Appservice -> homeserver token (used as the access_token when
+        // PIPO calls the client-server API).
+        as_token: Arc<String>,
+        // Homeserver -> appservice token (used to authenticate the
+        // inbound transaction pushes from the homeserver).
+        hs_token: Arc<String>,
+        // Localpart of the appservice's own user, matching the
+        // registration's "sender_localpart", e.g. "pipo".
+        sender_localpart: Arc<String>,
+        // Localpart prefix for ghost (puppet) users, matching the prefix
+        // of the registration's users namespace regex, e.g. "pipo_".
+        ghost_prefix: Arc<String>,
+        // Address the inbound appservice HTTP listener binds to, e.g.
+        // "0.0.0.0:8090".
+        listen_addr: Arc<String>,
+        // Matrix room ID -> bus id.
+        channel_mapping: HashMap<Arc<String>, Arc<String>>,
+    },
 }
 
 #[derive(Deserialize, Debug)]
@@ -314,7 +344,8 @@ pub async fn inner_main() -> anyhow::Result<()> {
                                            slackid   TEXT,
                                            discordid INTEGER,
                                            ircid     TEXT,
-                                           modtime   DEFAULT 
+                                           matrixid  TEXT,
+                                           modtime   DEFAULT
                                              (strftime('%Y-%m-%d %H:%M:%S:%s',
                                                        'now', 
                                                        'localtime'))
@@ -340,6 +371,15 @@ pub async fn inner_main() -> anyhow::Result<()> {
                     .any(|column| column == "ircid");
                 if !ircid_exists {
                     conn.execute("ALTER TABLE messages ADD COLUMN ircid TEXT", [])?;
+                }
+
+                let matrixid_exists = conn
+                    .prepare("PRAGMA table_info(messages)")?
+                    .query_map([], |row| row.get::<usize, String>(1))?
+                    .filter_map(Result::ok)
+                    .any(|column| column == "matrixid");
+                if !matrixid_exists {
+                    conn.execute("ALTER TABLE messages ADD COLUMN matrixid TEXT", [])?;
                 }
 
                 Ok(
@@ -579,6 +619,43 @@ pub async fn inner_main() -> anyhow::Result<()> {
                        {:#}",
                                 e
                             );
+                        }
+                    }
+                });
+                all_transport_tasks.push(handle);
+            }
+            ConfigTransport::Matrix {
+                homeserver,
+                use_tls,
+                server_name,
+                as_token,
+                hs_token,
+                sender_localpart,
+                ghost_prefix,
+                listen_addr,
+                channel_mapping,
+            } => {
+                let mut instance = Matrix::new(
+                    transport_id,
+                    &bus_map,
+                    pipo_id.clone(),
+                    db_pool.clone(),
+                    homeserver.to_string(),
+                    *use_tls,
+                    server_name.to_string(),
+                    as_token.to_string(),
+                    hs_token.to_string(),
+                    sender_localpart.to_string(),
+                    ghost_prefix.to_string(),
+                    listen_addr.to_string(),
+                    &channel_mapping,
+                )
+                .await?;
+                let handle = tokio::spawn(async move {
+                    match instance.connect().await {
+                        Ok(_) => eprintln!("Matrix::connect() exited Ok"),
+                        Err(e) => {
+                            eprintln!("Matrix::connect() exited with Error: {:#}", e);
                         }
                     }
                 });

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,0 +1,1114 @@
+//! Matrix transport.
+//!
+//! PIPO acts as a single Matrix Application Service (appservice) that bridges
+//! every other configured service. Because one bridge can register a user
+//! namespace regex that spans all of those services (e.g. `@pipo_.*`), remote
+//! senders are puppeted as distinct "ghost" Matrix users
+//! (`@pipo_irc_alice`, `@pipo_slack_bob`, ...) rather than relayed through a
+//! single bot account.
+//!
+//! Inbound events are pushed to us by the homeserver over HTTP
+//! (`PUT /_matrix/app/v1/transactions/{txnId}`); we host that listener with
+//! `axum`. Outbound sends use the Client-Server API via `reqwest`, masquerading
+//! as the relevant ghost with the appservice `?user_id=` query parameter and
+//! the `as_token` as the access token. The event *content* is built and parsed
+//! with `ruma`'s community-maintained types.
+//!
+//! v1 scope (both directions): plain text, edits (`m.replace`), deletes
+//! (redactions), and reactions (`m.reaction`). Attachments and threads are
+//! deferred; the code marks where they would hook in.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use anyhow::{anyhow, Context};
+use axum::{
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    routing::put,
+    Json, Router,
+};
+use deadpool_sqlite::Pool;
+use reqwest::{Client as HttpClient, Url};
+use ruma::{
+    events::{
+        reaction::ReactionEventContent,
+        relation::Annotation,
+        room::message::{ReplacementMetadata, RoomMessageEventContent},
+    },
+    EventId,
+};
+use rusqlite::params;
+use serde_json::{json, Value};
+use tokio::{net::TcpListener, sync::broadcast};
+use tokio_stream::{wrappers::BroadcastStream, StreamMap};
+
+use crate::Message;
+
+const TRANSPORT_NAME: &'static str = "Matrix";
+
+pub(crate) struct Matrix {
+    inner: Arc<MatrixInner>,
+}
+
+struct MatrixInner {
+    transport_id: usize,
+    http: HttpClient,
+    /// Base client-server API URL with no trailing slash.
+    homeserver_url: String,
+    server_name: String,
+    as_token: String,
+    hs_token: String,
+    /// The appservice's own user id, e.g. "@pipo:example.org".
+    sender_user_id: String,
+    sender_localpart: String,
+    ghost_prefix: String,
+    listen_addr: String,
+    /// Matrix room id -> the bus this transport publishes inbound events to.
+    room_to_bus: HashMap<String, broadcast::Sender<Message>>,
+    pool: Pool,
+    pipo_id: Arc<Mutex<i64>>,
+    /// Ghost localparts we've already registered.
+    registered_ghosts: Mutex<HashSet<String>>,
+    /// (user_id, room_id) pairs we've already joined.
+    joined: Mutex<HashSet<(String, String)>>,
+    /// Ghost user ids whose displayname we've already set this run.
+    displaynames_set: Mutex<HashSet<String>>,
+    /// Cache of inbound sender user id -> displayname (for nicer usernames).
+    displayname_cache: Mutex<HashMap<String, String>>,
+    /// Inbound transaction ids already processed (idempotency).
+    seen_txns: Mutex<HashSet<String>>,
+    /// (pipo_id, ghost_user_id, emoji_key) -> reaction event id, so an outbound
+    /// reaction removal can redact the reaction event we previously sent.
+    reaction_events: Mutex<HashMap<(i64, String, String), String>>,
+    /// Monotonic counter for outbound transaction ids.
+    txn_counter: AtomicU64,
+}
+
+impl Matrix {
+    pub async fn new(
+        transport_id: usize,
+        bus_map: &HashMap<String, broadcast::Sender<Message>>,
+        pipo_id: Arc<Mutex<i64>>,
+        pool: Pool,
+        homeserver: String,
+        use_tls: bool,
+        server_name: String,
+        as_token: String,
+        hs_token: String,
+        sender_localpart: String,
+        ghost_prefix: String,
+        listen_addr: String,
+        channel_mapping: &HashMap<Arc<String>, Arc<String>>,
+    ) -> anyhow::Result<Matrix> {
+        let room_to_bus = channel_mapping
+            .iter()
+            .filter_map(|(room_id, busname)| {
+                if let Some(sender) = bus_map.get(busname.as_ref()) {
+                    Some((room_id.as_ref().clone(), sender.clone()))
+                } else {
+                    eprintln!("No bus named '{}' in configuration file.", busname);
+                    None
+                }
+            })
+            .collect();
+
+        let scheme = if use_tls { "https" } else { "http" };
+        let homeserver_url = format!("{}://{}", scheme, homeserver.trim_end_matches('/'));
+        let sender_user_id = format!("@{}:{}", sender_localpart, server_name);
+
+        let inner = MatrixInner {
+            transport_id,
+            http: HttpClient::new(),
+            homeserver_url,
+            server_name,
+            as_token,
+            hs_token,
+            sender_user_id,
+            sender_localpart,
+            ghost_prefix,
+            listen_addr,
+            room_to_bus,
+            pool,
+            pipo_id,
+            registered_ghosts: Mutex::new(HashSet::new()),
+            joined: Mutex::new(HashSet::new()),
+            displaynames_set: Mutex::new(HashSet::new()),
+            displayname_cache: Mutex::new(HashMap::new()),
+            seen_txns: Mutex::new(HashSet::new()),
+            reaction_events: Mutex::new(HashMap::new()),
+            txn_counter: AtomicU64::new(0),
+        };
+
+        Ok(Matrix {
+            inner: Arc::new(inner),
+        })
+    }
+
+    pub async fn connect(&mut self) -> anyhow::Result<()> {
+        let inner = self.inner.clone();
+
+        // Ensure the appservice's own user exists (best effort).
+        if let Err(e) = inner.register_user(&inner.sender_localpart).await {
+            eprintln!("Matrix: couldn't register sender user: {:#}", e);
+        }
+
+        // Inbound: the homeserver PUTs transactions to us.
+        let app = Router::new()
+            .route(
+                "/_matrix/app/v1/transactions/{txn_id}",
+                put(handle_transaction),
+            )
+            // Legacy unstable path still used by some homeservers.
+            .route("/transactions/{txn_id}", put(handle_transaction))
+            .with_state(inner.clone());
+        let listener = TcpListener::bind(inner.listen_addr.as_str())
+            .await
+            .with_context(|| format!("Matrix: couldn't bind {}", inner.listen_addr))?;
+        eprintln!("Matrix: appservice listening on {}", inner.listen_addr);
+        let mut server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+        // Outbound: multiplex every mapped bus, keyed by destination room id.
+        let mut input_buses: StreamMap<String, BroadcastStream<Message>> = StreamMap::new();
+        for (room_id, sender) in inner.room_to_bus.iter() {
+            input_buses.insert(room_id.clone(), BroadcastStream::new(sender.subscribe()));
+        }
+
+        loop {
+            tokio::select! {
+                Some((room_id, message))
+                    = tokio_stream::StreamExt::next(&mut input_buses) => {
+                    match message {
+                        Ok(message) => inner.handle_outbound(&room_id, message).await,
+                        Err(e) => eprintln!("Matrix: bus stream error: {}", e),
+                    }
+                }
+                res = &mut server => {
+                    return match res {
+                        Ok(Ok(())) => Ok(()),
+                        Ok(Err(e)) => Err(anyhow!("Matrix inbound server error: {}", e)),
+                        Err(e) => Err(anyhow!("Matrix inbound server task failed: {}", e)),
+                    };
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: bus Message -> Matrix Client-Server API
+// ---------------------------------------------------------------------------
+
+impl MatrixInner {
+    async fn handle_outbound(&self, room_id: &str, message: Message) {
+        match message {
+            Message::Text {
+                sender,
+                pipo_id,
+                transport,
+                username,
+                thread: _,
+                message,
+                attachments: _,
+                is_edit,
+                irc_flag: _,
+                ..
+            } => {
+                if sender != self.transport_id {
+                    self.send_user_message(
+                        room_id, pipo_id, &transport, &username, message, is_edit, false,
+                    )
+                    .await;
+                }
+            }
+            Message::Action {
+                sender,
+                pipo_id,
+                transport,
+                username,
+                thread: _,
+                message,
+                attachments: _,
+                is_edit,
+                irc_flag: _,
+                ..
+            } => {
+                if sender != self.transport_id {
+                    self.send_user_message(
+                        room_id, pipo_id, &transport, &username, message, is_edit, true,
+                    )
+                    .await;
+                }
+            }
+            Message::Bot {
+                sender,
+                pipo_id,
+                transport: _,
+                message,
+                attachments: _,
+                is_edit,
+            } => {
+                if sender != self.transport_id && !is_edit {
+                    self.send_bot_message(room_id, pipo_id, message).await;
+                }
+            }
+            Message::Delete {
+                sender,
+                pipo_id,
+                transport: _,
+            } => {
+                if sender != self.transport_id {
+                    self.handle_outbound_delete(room_id, pipo_id).await;
+                }
+            }
+            Message::Reaction {
+                sender,
+                pipo_id,
+                transport: _,
+                emoji,
+                remove,
+                username,
+                thread: _,
+                ..
+            } => {
+                if sender != self.transport_id {
+                    self.handle_outbound_reaction(room_id, pipo_id, &emoji, remove, username)
+                        .await;
+                }
+            }
+            // Not represented in Matrix rooms for v1.
+            Message::Names { .. } | Message::Pin { .. } => {}
+        }
+    }
+
+    /// Send (or edit) a text/emote message puppeted as the sender's ghost.
+    async fn send_user_message(
+        &self,
+        room_id: &str,
+        pipo_id: i64,
+        transport: &str,
+        username: &str,
+        message: Option<String>,
+        is_edit: bool,
+        emote: bool,
+    ) {
+        let message = match message {
+            Some(m) if !m.is_empty() => m,
+            _ => return,
+        };
+
+        let ghost = self.ghost_user_id(transport, username);
+        if let Err(e) = self.ensure_ghost(&ghost, username).await {
+            eprintln!("Matrix: couldn't prepare ghost {}: {:#}", ghost, e);
+            return;
+        }
+        if let Err(e) = self.ensure_joined(&ghost, room_id).await {
+            eprintln!("Matrix: ghost {} couldn't join {}: {:#}", ghost, room_id, e);
+            return;
+        }
+
+        let content = if is_edit {
+            // Resolve the original Matrix event to replace.
+            match self.select_matrixid_from_messages(pipo_id).await {
+                Some(orig) => match EventId::parse(&orig) {
+                    Ok(orig_id) => {
+                        let new = if emote {
+                            RoomMessageEventContent::emote_plain(message)
+                        } else {
+                            RoomMessageEventContent::text_plain(message)
+                        };
+                        new.make_replacement(ReplacementMetadata::new(orig_id, None))
+                    }
+                    Err(_) => return,
+                },
+                // Nothing to edit on the Matrix side; drop it.
+                None => return,
+            }
+        } else if emote {
+            RoomMessageEventContent::emote_plain(message)
+        } else {
+            RoomMessageEventContent::text_plain(message)
+        };
+        // Attachments/threads would be attached to `content` here in a later
+        // revision (media upload + `m.image`/`m.file`, `m.thread` relations).
+
+        let content = match serde_json::to_value(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Matrix: couldn't serialize message content: {:#}", e);
+                return;
+            }
+        };
+
+        match self
+            .send_event(Some(&ghost), room_id, "m.room.message", content)
+            .await
+        {
+            Ok(event_id) => {
+                if !is_edit {
+                    // Remember pipo_id <-> Matrix event id so later edits,
+                    // deletes and reactions can find this message.
+                    if let Err(e) = self.update_messages_matrixid(pipo_id, Some(event_id)).await {
+                        eprintln!("Matrix: couldn't store matrixid: {:#}", e);
+                    }
+                }
+            }
+            Err(e) => eprintln!("Matrix: send to {} failed: {:#}", room_id, e),
+        }
+    }
+
+    /// Send a bot/system notice as the appservice's own user.
+    async fn send_bot_message(&self, room_id: &str, pipo_id: i64, message: Option<String>) {
+        let message = match message {
+            Some(m) if !m.is_empty() => m,
+            _ => return,
+        };
+        if let Err(e) = self.ensure_joined(&self.sender_user_id, room_id).await {
+            eprintln!("Matrix: sender user couldn't join {}: {:#}", room_id, e);
+            return;
+        }
+        let content = match serde_json::to_value(RoomMessageEventContent::notice_plain(message)) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Matrix: couldn't serialize notice content: {:#}", e);
+                return;
+            }
+        };
+        // `None` user_id => acts as the appservice sender user.
+        match self.send_event(None, room_id, "m.room.message", content).await {
+            Ok(event_id) => {
+                if let Err(e) = self.update_messages_matrixid(pipo_id, Some(event_id)).await {
+                    eprintln!("Matrix: couldn't store matrixid: {:#}", e);
+                }
+            }
+            Err(e) => eprintln!("Matrix: bot send to {} failed: {:#}", room_id, e),
+        }
+    }
+
+    async fn handle_outbound_delete(&self, room_id: &str, pipo_id: i64) {
+        let event_id = match self.select_matrixid_from_messages(pipo_id).await {
+            Some(id) => id,
+            None => return,
+        };
+        // Redact as the appservice sender user, which is expected to hold a
+        // moderator power level in bridged rooms.
+        if let Err(e) = self.redact(None, room_id, &event_id).await {
+            eprintln!("Matrix: redact in {} failed: {:#}", room_id, e);
+        }
+    }
+
+    async fn handle_outbound_reaction(
+        &self,
+        room_id: &str,
+        pipo_id: i64,
+        emoji: &str,
+        remove: bool,
+        username: Option<String>,
+    ) {
+        let key = self.emoji_to_key(emoji);
+        // React as the reactor's ghost when a username is known, so that
+        // distinct users' identical reactions don't collide. The origin
+        // transport isn't carried on a reaction, so the ghost omits the
+        // service segment (e.g. `@pipo_alice`). Without a username we react as
+        // the appservice sender user.
+        let actor = username
+            .as_deref()
+            .map(|u| self.ghost_user_id("", u));
+        let actor_key = actor.clone().unwrap_or_default();
+
+        if remove {
+            let stored = {
+                let map = self.reaction_events.lock().unwrap();
+                map.get(&(pipo_id, actor_key, key)).cloned()
+            };
+            if let Some(reaction_event) = stored {
+                if let Err(e) = self.redact(actor.as_deref(), room_id, &reaction_event).await {
+                    eprintln!("Matrix: reaction redact failed: {:#}", e);
+                }
+            }
+            return;
+        }
+
+        let target = match self.select_matrixid_from_messages(pipo_id).await {
+            Some(id) => id,
+            None => return,
+        };
+        let target_id = match EventId::parse(&target) {
+            Ok(id) => id,
+            Err(_) => return,
+        };
+
+        if let (Some(actor), Some(username)) = (actor.as_deref(), username.as_deref()) {
+            if let Err(e) = self.ensure_ghost(actor, username).await {
+                eprintln!("Matrix: couldn't prepare reacting ghost {}: {:#}", actor, e);
+                return;
+            }
+            if let Err(e) = self.ensure_joined(actor, room_id).await {
+                eprintln!("Matrix: reacting ghost couldn't join: {:#}", e);
+                return;
+            }
+        }
+
+        let content = match serde_json::to_value(ReactionEventContent::new(Annotation::new(
+            target_id,
+            key.clone(),
+        ))) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Matrix: couldn't serialize reaction: {:#}", e);
+                return;
+            }
+        };
+        match self.send_event(actor.as_deref(), room_id, "m.reaction", content).await {
+            Ok(reaction_event) => {
+                let mut map = self.reaction_events.lock().unwrap();
+                map.insert((pipo_id, actor_key, key), reaction_event);
+            }
+            Err(e) => eprintln!("Matrix: reaction send failed: {:#}", e),
+        }
+    }
+
+    // -- ghost / membership management --------------------------------------
+
+    async fn ensure_ghost(&self, user_id: &str, display: &str) -> anyhow::Result<()> {
+        let localpart = localpart_of(user_id).unwrap_or(user_id).to_string();
+        let already = {
+            let set = self.registered_ghosts.lock().unwrap();
+            set.contains(&localpart)
+        };
+        if !already {
+            self.register_user(&localpart).await?;
+            self.registered_ghosts.lock().unwrap().insert(localpart);
+        }
+
+        let display_done = {
+            let set = self.displaynames_set.lock().unwrap();
+            set.contains(user_id)
+        };
+        if !display_done {
+            if let Err(e) = self.set_displayname(user_id, display).await {
+                eprintln!("Matrix: couldn't set displayname for {}: {:#}", user_id, e);
+            } else {
+                self.displaynames_set
+                    .lock()
+                    .unwrap()
+                    .insert(user_id.to_string());
+            }
+        }
+        Ok(())
+    }
+
+    async fn ensure_joined(&self, user_id: &str, room_id: &str) -> anyhow::Result<()> {
+        let key = (user_id.to_string(), room_id.to_string());
+        {
+            let set = self.joined.lock().unwrap();
+            if set.contains(&key) {
+                return Ok(());
+            }
+        }
+        self.join_room(user_id, room_id).await?;
+        self.joined.lock().unwrap().insert(key);
+        Ok(())
+    }
+
+    async fn register_user(&self, localpart: &str) -> anyhow::Result<()> {
+        let url = self.client_url(&["register"])?;
+        let resp = self
+            .http
+            .post(url)
+            .bearer_auth(&self.as_token)
+            .json(&json!({
+                "type": "m.login.application_service",
+                "username": localpart,
+            }))
+            .send()
+            .await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        // A user that already exists is fine.
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if body.contains("M_USER_IN_USE") {
+            return Ok(());
+        }
+        Err(anyhow!("register {} -> {}: {}", localpart, status, body))
+    }
+
+    async fn set_displayname(&self, user_id: &str, name: &str) -> anyhow::Result<()> {
+        let mut url = self.client_url(&["profile", user_id, "displayname"])?;
+        url.query_pairs_mut().append_pair("user_id", user_id);
+        let resp = self
+            .http
+            .put(url)
+            .bearer_auth(&self.as_token)
+            .json(&json!({ "displayname": name }))
+            .send()
+            .await?;
+        expect_success(resp, "set_displayname").await
+    }
+
+    async fn join_room(&self, user_id: &str, room_id: &str) -> anyhow::Result<()> {
+        let mut url = self.client_url(&["join", room_id])?;
+        if user_id != self.sender_user_id {
+            url.query_pairs_mut().append_pair("user_id", user_id);
+        }
+        let resp = self
+            .http
+            .post(url)
+            .bearer_auth(&self.as_token)
+            .json(&json!({}))
+            .send()
+            .await?;
+        expect_success(resp, "join_room").await
+    }
+
+    async fn send_event(
+        &self,
+        user_id: Option<&str>,
+        room_id: &str,
+        event_type: &str,
+        content: Value,
+    ) -> anyhow::Result<String> {
+        let txn = self.next_txn();
+        let mut url = self.client_url(&["rooms", room_id, "send", event_type, &txn])?;
+        if let Some(user_id) = user_id {
+            url.query_pairs_mut().append_pair("user_id", user_id);
+        }
+        let resp = self
+            .http
+            .put(url)
+            .bearer_auth(&self.as_token)
+            .json(&content)
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("send {} -> {}: {}", event_type, status, body));
+        }
+        let value: Value = serde_json::from_str(&body).unwrap_or_default();
+        value
+            .get("event_id")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .ok_or_else(|| anyhow!("send response missing event_id: {}", body))
+    }
+
+    async fn redact(
+        &self,
+        user_id: Option<&str>,
+        room_id: &str,
+        event_id: &str,
+    ) -> anyhow::Result<String> {
+        let txn = self.next_txn();
+        let mut url = self.client_url(&["rooms", room_id, "redact", event_id, &txn])?;
+        if let Some(user_id) = user_id {
+            url.query_pairs_mut().append_pair("user_id", user_id);
+        }
+        let resp = self
+            .http
+            .put(url)
+            .bearer_auth(&self.as_token)
+            .json(&json!({}))
+            .send()
+            .await?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!("redact -> {}: {}", status, body));
+        }
+        let value: Value = serde_json::from_str(&body).unwrap_or_default();
+        Ok(value
+            .get("event_id")
+            .and_then(Value::as_str)
+            .map(String::from)
+            .unwrap_or_default())
+    }
+
+    // -- helpers ------------------------------------------------------------
+
+    fn client_url(&self, segments: &[&str]) -> anyhow::Result<Url> {
+        let mut url = Url::parse(&self.homeserver_url).context("invalid homeserver_url")?;
+        {
+            let mut path = url
+                .path_segments_mut()
+                .map_err(|_| anyhow!("homeserver_url cannot be a base"))?;
+            path.pop_if_empty();
+            path.extend(["_matrix", "client", "v3"]);
+            path.extend(segments);
+        }
+        Ok(url)
+    }
+
+    fn next_txn(&self) -> String {
+        let n = self.txn_counter.fetch_add(1, Ordering::Relaxed);
+        format!("pipo{}", n)
+    }
+
+    fn ghost_user_id(&self, transport: &str, username: &str) -> String {
+        let svc = sanitize_localpart(transport);
+        let user = sanitize_localpart(username);
+        if svc.is_empty() {
+            format!("@{}{}:{}", self.ghost_prefix, user, self.server_name)
+        } else {
+            format!("@{}{}_{}:{}", self.ghost_prefix, svc, user, self.server_name)
+        }
+    }
+
+    /// True if `user_id` belongs to this appservice (a ghost or the sender
+    /// user), i.e. an event we authored and should not re-bridge.
+    fn is_our_user(&self, user_id: &str) -> bool {
+        if user_id == self.sender_user_id {
+            return true;
+        }
+        match localpart_of(user_id) {
+            Some(local) => local.starts_with(self.ghost_prefix.as_str()),
+            None => false,
+        }
+    }
+
+    fn emoji_to_key(&self, emoji: &str) -> String {
+        emojis::get_by_shortcode(emoji)
+            .map(|e| e.as_str().to_string())
+            .unwrap_or_else(|| emoji.to_string())
+    }
+
+    async fn display_name_for(&self, user_id: &str) -> String {
+        if let Some(name) = self.displayname_cache.lock().unwrap().get(user_id).cloned() {
+            return name;
+        }
+        let fallback = localpart_of(user_id).unwrap_or(user_id).to_string();
+        let name = match self.client_url(&["profile", user_id, "displayname"]) {
+            Ok(url) => match self.http.get(url).bearer_auth(&self.as_token).send().await {
+                Ok(resp) if resp.status().is_success() => resp
+                    .json::<Value>()
+                    .await
+                    .ok()
+                    .and_then(|v| v.get("displayname").and_then(Value::as_str).map(String::from))
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(fallback),
+                _ => fallback,
+            },
+            Err(_) => fallback,
+        };
+        self.displayname_cache
+            .lock()
+            .unwrap()
+            .insert(user_id.to_string(), name.clone());
+        name
+    }
+
+    // -- SQLite id mapping (mirrors the ircid helpers in src/irc.rs) --------
+
+    async fn insert_into_messages_table(&self) -> anyhow::Result<i64> {
+        let conn = self.pool.get().await.unwrap();
+        let pipo_id = *self.pipo_id.lock().unwrap();
+
+        match conn
+            .interact(move |conn| -> anyhow::Result<usize> {
+                Ok(conn.execute(
+                    "INSERT OR REPLACE INTO messages (id) VALUES (?1)",
+                    params![pipo_id],
+                )?)
+            })
+            .await
+        {
+            Ok(res) => res,
+            Err(_) => Err(anyhow!("Interact Error")),
+        }?;
+
+        let ret = pipo_id;
+        let mut pipo_id = self.pipo_id.lock().unwrap();
+        *pipo_id += 1;
+        if *pipo_id > 40000 {
+            *pipo_id = 0
+        }
+
+        Ok(ret)
+    }
+
+    async fn update_messages_matrixid(
+        &self,
+        pipo_id: i64,
+        matrix_event_id: Option<String>,
+    ) -> anyhow::Result<()> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<usize> {
+            Ok(conn.execute(
+                "UPDATE messages SET matrixid = ?2 WHERE id = ?1",
+                params![pipo_id, matrix_event_id],
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))?;
+
+        Ok(())
+    }
+
+    async fn select_matrixid_from_messages(&self, pipo_id: i64) -> Option<String> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<String>> {
+            Ok(conn.query_row(
+                "SELECT matrixid FROM messages WHERE id = ?1",
+                params![pipo_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+
+    async fn select_pipo_id_by_matrixid(&self, matrix_event_id: String) -> Option<i64> {
+        let conn = self.pool.get().await.unwrap();
+
+        conn.interact(move |conn| -> anyhow::Result<Option<i64>> {
+            Ok(conn.query_row(
+                "SELECT id FROM messages WHERE matrixid = ?1",
+                params![matrix_event_id],
+                |row| row.get(0),
+            )?)
+        })
+        .await
+        .unwrap_or_else(|_| Err(anyhow!("Interact Error")))
+        .ok()
+        .flatten()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Inbound: homeserver transaction -> bus Message
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct QueryParams {
+    access_token: Option<String>,
+}
+
+async fn handle_transaction(
+    State(inner): State<Arc<MatrixInner>>,
+    Path(txn_id): Path<String>,
+    headers: HeaderMap,
+    Query(params): Query<QueryParams>,
+    body: Bytes,
+) -> (StatusCode, Json<Value>) {
+    // Authenticate the homeserver via the hs_token (bearer header preferred,
+    // legacy access_token query parameter accepted).
+    let bearer = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(str::to_string);
+    let presented = bearer.or(params.access_token);
+    if presented.as_deref() != Some(inner.hs_token.as_str()) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "errcode": "M_FORBIDDEN" })),
+        );
+    }
+
+    // Idempotency: the homeserver retries transactions until it gets a 200.
+    {
+        let mut seen = inner.seen_txns.lock().unwrap();
+        if seen.contains(&txn_id) {
+            return (StatusCode::OK, Json(json!({})));
+        }
+        // Keep the set from growing without bound.
+        if seen.len() > 10_000 {
+            seen.clear();
+        }
+        seen.insert(txn_id);
+    }
+
+    let transaction: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Matrix: couldn't parse transaction: {:#}", e);
+            // Ack anyway so the homeserver stops retrying a malformed body.
+            return (StatusCode::OK, Json(json!({})));
+        }
+    };
+
+    if let Some(events) = transaction.get("events").and_then(Value::as_array) {
+        for event in events {
+            inner.handle_inbound_event(event).await;
+        }
+    }
+
+    (StatusCode::OK, Json(json!({})))
+}
+
+impl MatrixInner {
+    async fn handle_inbound_event(&self, event: &Value) {
+        let event_type = event.get("type").and_then(Value::as_str).unwrap_or_default();
+        let sender = event.get("sender").and_then(Value::as_str).unwrap_or_default();
+        let room_id = event.get("room_id").and_then(Value::as_str).unwrap_or_default();
+        let event_id = event.get("event_id").and_then(Value::as_str).unwrap_or_default();
+
+        // Loop prevention: never re-bridge events we authored.
+        if sender.is_empty() || self.is_our_user(sender) {
+            return;
+        }
+        // Only bridge rooms we're configured for.
+        if !self.room_to_bus.contains_key(room_id) {
+            return;
+        }
+
+        match event_type {
+            "m.room.message" => self.inbound_message(room_id, sender, event_id, event).await,
+            "m.reaction" => self.inbound_reaction(room_id, sender, event).await,
+            "m.room.redaction" => self.inbound_redaction(room_id, event).await,
+            _ => {}
+        }
+    }
+
+    async fn inbound_message(&self, room_id: &str, sender: &str, event_id: &str, event: &Value) {
+        let content = match event.get("content") {
+            Some(c) => c,
+            None => return,
+        };
+        let msgtype = content.get("msgtype").and_then(Value::as_str).unwrap_or("m.text");
+
+        // Is this an edit (m.replace)?
+        let relates = content.get("m.relates_to");
+        let is_replace = relates
+            .and_then(|r| r.get("rel_type"))
+            .and_then(Value::as_str)
+            == Some("m.replace");
+
+        let username = self.display_name_for(sender).await;
+
+        if is_replace {
+            let target = relates
+                .and_then(|r| r.get("event_id"))
+                .and_then(Value::as_str);
+            let new_body = content
+                .get("m.new_content")
+                .and_then(|c| c.get("body"))
+                .and_then(Value::as_str);
+            let (Some(target), Some(new_body)) = (target, new_body) else {
+                return;
+            };
+            let pipo_id = match self.select_pipo_id_by_matrixid(target.to_string()).await {
+                Some(id) => id,
+                // We don't know the original message; ignore the edit.
+                None => return,
+            };
+            let message = self.build_text_message(pipo_id, msgtype, username, new_body, true);
+            self.publish(room_id, message);
+            return;
+        }
+
+        let body = match content.get("body").and_then(Value::as_str) {
+            Some(b) if !b.is_empty() => b,
+            _ => return,
+        };
+
+        let pipo_id = match self.insert_into_messages_table().await {
+            Ok(id) => id,
+            Err(e) => {
+                eprintln!("Matrix: couldn't allocate pipo_id: {:#}", e);
+                return;
+            }
+        };
+        if let Err(e) = self
+            .update_messages_matrixid(pipo_id, Some(event_id.to_string()))
+            .await
+        {
+            eprintln!("Matrix: couldn't store inbound matrixid: {:#}", e);
+        }
+
+        let message = self.build_text_message(pipo_id, msgtype, username, body, false);
+        self.publish(room_id, message);
+    }
+
+    fn build_text_message(
+        &self,
+        pipo_id: i64,
+        msgtype: &str,
+        username: String,
+        body: &str,
+        is_edit: bool,
+    ) -> Message {
+        let common = (
+            self.transport_id,
+            pipo_id,
+            TRANSPORT_NAME.to_string(),
+            username,
+            Some(body.to_string()),
+            is_edit,
+        );
+        let (sender, pipo_id, transport, username, message, is_edit) = common;
+        if msgtype == "m.emote" {
+            Message::Action {
+                sender,
+                pipo_id,
+                transport,
+                username,
+                avatar_url: None,
+                thread: None,
+                message,
+                attachments: None,
+                is_edit,
+                irc_flag: false,
+            }
+        } else {
+            Message::Text {
+                sender,
+                pipo_id,
+                transport,
+                username,
+                avatar_url: None,
+                thread: None,
+                message,
+                attachments: None,
+                is_edit,
+                irc_flag: false,
+            }
+        }
+    }
+
+    async fn inbound_reaction(&self, room_id: &str, sender: &str, event: &Value) {
+        let relates = match event.get("content").and_then(|c| c.get("m.relates_to")) {
+            Some(r) => r,
+            None => return,
+        };
+        let target = relates.get("event_id").and_then(Value::as_str);
+        let key = relates.get("key").and_then(Value::as_str);
+        let (Some(target), Some(key)) = (target, key) else {
+            return;
+        };
+        let pipo_id = match self.select_pipo_id_by_matrixid(target.to_string()).await {
+            Some(id) => id,
+            None => return,
+        };
+        let username = self.display_name_for(sender).await;
+        let emoji = key_to_emoji(key);
+        self.publish(
+            room_id,
+            Message::Reaction {
+                sender: self.transport_id,
+                pipo_id,
+                transport: TRANSPORT_NAME.to_string(),
+                emoji,
+                remove: false,
+                username: Some(username),
+                avatar_url: None,
+                thread: None,
+            },
+        );
+    }
+
+    async fn inbound_redaction(&self, room_id: &str, event: &Value) {
+        // `redacts` is top-level in older room versions and in `content` in
+        // newer ones.
+        let redacts = event
+            .get("redacts")
+            .and_then(Value::as_str)
+            .or_else(|| event.get("content").and_then(|c| c.get("redacts")).and_then(Value::as_str));
+        let redacts = match redacts {
+            Some(r) => r,
+            None => return,
+        };
+        let pipo_id = match self.select_pipo_id_by_matrixid(redacts.to_string()).await {
+            Some(id) => id,
+            None => return,
+        };
+        self.publish(
+            room_id,
+            Message::Delete {
+                sender: self.transport_id,
+                pipo_id,
+                transport: TRANSPORT_NAME.to_string(),
+            },
+        );
+    }
+
+    fn publish(&self, room_id: &str, message: Message) {
+        if let Some(sender) = self.room_to_bus.get(room_id) {
+            if let Err(e) = sender.send(message) {
+                eprintln!("Matrix: couldn't publish to bus for {}: {:#}", room_id, e);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the localpart of a Matrix user id (`@local:server` -> `local`).
+fn localpart_of(user_id: &str) -> Option<&str> {
+    user_id
+        .strip_prefix('@')
+        .and_then(|rest| rest.split(':').next())
+}
+
+/// Map an arbitrary display name/service name to a valid Matrix localpart
+/// fragment: lowercase, keeping only `[a-z0-9._=/-]`, other characters become
+/// `_`.
+fn sanitize_localpart(s: &str) -> String {
+    s.chars()
+        .flat_map(char::to_lowercase)
+        .map(|c| match c {
+            'a'..='z' | '0'..='9' | '.' | '_' | '=' | '-' | '/' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+/// Convert a Matrix reaction key (usually a unicode emoji) to a shortcode name
+/// when we recognise it, matching how other transports refer to emoji.
+fn key_to_emoji(key: &str) -> String {
+    emojis::get(key)
+        .and_then(|e| e.shortcode())
+        .map(str::to_string)
+        .unwrap_or_else(|| key.to_string())
+}
+
+async fn expect_success(resp: reqwest::Response, what: &str) -> anyhow::Result<()> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = resp.text().await.unwrap_or_default();
+    Err(anyhow!("{} -> {}: {}", what, status, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn localpart_extraction() {
+        assert_eq!(localpart_of("@pipo_irc_alice:example.org"), Some("pipo_irc_alice"));
+        assert_eq!(localpart_of("@pipo:example.org"), Some("pipo"));
+        assert_eq!(localpart_of("not-a-user"), None);
+    }
+
+    #[test]
+    fn localpart_sanitization() {
+        assert_eq!(sanitize_localpart("Alice"), "alice");
+        assert_eq!(sanitize_localpart("A B!C"), "a_b_c");
+        assert_eq!(sanitize_localpart("user.name_1"), "user.name_1");
+        assert_eq!(sanitize_localpart("IRC"), "irc");
+    }
+
+    #[test]
+    fn emoji_shortcode_roundtrip() {
+        // Known emoji maps unicode -> shortcode and back.
+        assert_eq!(key_to_emoji("😀"), "grinning");
+        // Unknown reaction keys pass through unchanged.
+        assert_eq!(key_to_emoji("+1-custom"), "+1-custom");
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a complete Matrix transport implementation to PIPO, enabling bridging of Matrix rooms alongside existing IRC, Slack, Discord, and Mumble transports. The implementation follows PIPO's architecture of puppeting remote senders as distinct "ghost" Matrix users rather than relaying through a single bot account.

## Key Changes

- **New Matrix transport module** (`src/matrix.rs`): A 1100+ line implementation providing:
  - Application Service (appservice) pattern with HTTP inbound listener (via `axum`)
  - Outbound message sending via Matrix Client-Server API (via `reqwest`)
  - Ghost user management with automatic registration and displayname setting
  - Support for text messages, edits (`m.replace`), deletes (redactions), and reactions (`m.reaction`)
  - SQLite-backed message ID mapping for tracking Matrix event IDs across the bridge
  - Idempotent transaction handling and loop prevention

- **Configuration support**: Added `Matrix` variant to `ConfigTransport` enum with fields for:
  - Homeserver connection details (host, TLS, server name)
  - Authentication tokens (as_token, hs_token)
  - Appservice identity (sender_localpart, ghost_prefix)
  - HTTP listener binding address
  - Room-to-bus channel mapping

- **Database schema update**: Added `matrixid` column to the `messages` table for storing Matrix event IDs, mirroring existing IRC/Discord/Slack ID mapping patterns

- **Documentation**: 
  - Comprehensive `docs/matrix-transport.md` explaining the appservice pattern, configuration, and v1 scope
  - Example registration file `docs/pipo-registration.example.yaml` for operator reference

- **Dependencies**: Added `axum` (0.8) for the inbound HTTP server

## Implementation Details

- **Ghost user strategy**: Remote senders are puppeted as `@pipo_<service>_<username>:<server>` users, allowing distinct reactions and presence per sender
- **Bidirectional bridging**: Inbound events from Matrix are converted to `Message` enum variants and published to configured buses; outbound messages are sent as the appropriate ghost or appservice sender
- **Event type support**: Handles `m.room.message` (text/emote), `m.reaction`, and `m.room.redaction` events
- **Emoji handling**: Uses the `emojis` crate to convert between Unicode emoji and shortcodes for consistent representation across transports
- **Deferred features**: Code structure marks where attachments/media and threads would integrate in future revisions; encrypted rooms are explicitly out of v1 scope

https://claude.ai/code/session_01Pv3E3ePf5Jg7QaoXZAtuSR