### PR TITLE
Add integration-testing workflow for PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,61 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+      - 'feature/**'
+
+concurrency:
+  group: integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Always-on integration tests: the in-process startup suite plus a fully
+  # credential-free IRC bridging test against a bare ircd service container.
+  # Runs on every PR, including forks (no secrets required).
+  startup-and-irc:
+    runs-on: ubuntu-latest
+    services:
+      # Bare standalone ircd on plaintext 6667, no auth. Service containers
+      # cannot mount repo config (the repo isn't checked out when they start),
+      # so a working-by-default image is required.
+      ircd:
+        image: inspircd/inspircd-docker
+        ports:
+          - 6667:6667
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install_deps
+        run: sudo apt install -y protobuf-compiler libsqlite3-dev libssl-dev
+
+      - name: Integration tests (startup + IRC bridge)
+        env:
+          PIPO_IT_IRC_SERVER: 127.0.0.1:6667
+        run: cargo test --locked --verbose --test startup --test irc_bridge
+
+  # Live-service connect/startup smoke tests against real Discord and Slack.
+  # The tests self-skip when their secrets are absent, so this job passes on
+  # fork PRs and only actually exercises the services when the repo owner has
+  # provisioned the secrets below.
+  live-service-smoke:
+    runs-on: ubuntu-latest
+    env:
+      PIPO_IT_DISCORD_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      PIPO_IT_DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
+      PIPO_IT_DISCORD_CHANNEL_ID: ${{ secrets.DISCORD_CHANNEL_ID }}
+      PIPO_IT_SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_LEVEL_TOKEN }}
+      PIPO_IT_SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      PIPO_IT_SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install_deps
+        run: sudo apt install -y protobuf-compiler libsqlite3-dev libssl-dev
+
+      - name: Live-service smoke tests (self-skip without secrets)
+        run: cargo test --locked --verbose --test discord_smoke --test slack_smoke

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,114 @@
+//! Shared helpers for pipo's integration tests.
+//!
+//! Because pipo's internals (the `Message` enum, config types, buses) are all
+//! private, integration tests drive the system through the compiled binary
+//! (`env!("CARGO_BIN_EXE_pipo")`) with real temp config + database files.
+
+#![allow(dead_code)]
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Absolute path to the compiled `pipo` binary for this test run.
+pub const PIPO_BIN: &str = env!("CARGO_BIN_EXE_pipo");
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A unique path under the system temp dir, safe for parallel tests.
+pub fn unique_tmp(suffix: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut path = std::env::temp_dir();
+    path.push(format!("pipo-it-{}-{}-{}-{}", std::process::id(), n, nanos, suffix));
+    path
+}
+
+/// Write `json` to a fresh temp config file and return its path.
+pub fn write_config(json: &str) -> PathBuf {
+    let path = unique_tmp("config.json");
+    std::fs::write(&path, json).expect("failed to write temp config");
+    path
+}
+
+/// Run pipo to completion (for configs where the process exits on its own,
+/// e.g. no transports or a bad config) and capture its output.
+pub fn run_pipo_to_completion(args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(PIPO_BIN);
+    cmd.args(args);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("failed to run pipo")
+}
+
+/// A running pipo process. Its stdout/stderr are redirected to temp files
+/// (avoiding pipe-buffer deadlock for long-lived processes) and it is killed
+/// when this guard is dropped, so cleanup survives test panics.
+pub struct PipoProcess {
+    child: Child,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl PipoProcess {
+    /// True while the process is still running.
+    pub fn is_running(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    pub fn stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_path).unwrap_or_default()
+    }
+
+    pub fn stdout(&self) -> String {
+        std::fs::read_to_string(&self.stdout_path).unwrap_or_default()
+    }
+}
+
+impl Drop for PipoProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn a long-lived pipo process against `config_path` and `db_path`.
+pub fn spawn_pipo(config_path: &Path, db_path: &Path) -> PipoProcess {
+    let stdout_path = unique_tmp("stdout.log");
+    let stderr_path = unique_tmp("stderr.log");
+    let child = Command::new(PIPO_BIN)
+        .arg(config_path)
+        .arg(db_path)
+        .stdout(Stdio::from(File::create(&stdout_path).expect("create stdout log")))
+        .stderr(Stdio::from(File::create(&stderr_path).expect("create stderr log")))
+        .spawn()
+        .expect("failed to spawn pipo");
+    PipoProcess {
+        child,
+        stdout_path,
+        stderr_path,
+    }
+}
+
+/// Return the values of the given env vars, or `None` (printing a SKIP notice)
+/// if any is unset or empty. Lets live-service tests self-skip locally and on
+/// fork PRs where the corresponding secrets are unavailable.
+pub fn env_or_skip(vars: &[&str]) -> Option<Vec<String>> {
+    let mut values = Vec::with_capacity(vars.len());
+    for var in vars {
+        match std::env::var(var) {
+            Ok(val) if !val.is_empty() => values.push(val),
+            _ => {
+                eprintln!("SKIP: env var {var} is not set; skipping live-service test");
+                return None;
+            }
+        }
+    }
+    Some(values)
+}

--- a/tests/discord_smoke.rs
+++ b/tests/discord_smoke.rs
@@ -1,0 +1,75 @@
+//! Live Discord connect + startup smoke test.
+//!
+//! pipo ignores bot-authored inbound messages, so a bot token cannot originate
+//! a message pipo would relay — a full bridge assertion would need a human/user
+//! token (which for Discord violates its ToS). Instead we assert pipo's real,
+//! observable startup side-effect: on connect it creates a webhook named
+//! `PIPO <channel_id>` in each mapped channel. The test reads that channel's
+//! webhooks via the Discord REST API and waits for it to appear.
+//!
+//! Self-skips unless `PIPO_IT_DISCORD_TOKEN`, `PIPO_IT_DISCORD_GUILD_ID` and
+//! `PIPO_IT_DISCORD_CHANNEL_ID` are all set (the workflow maps repo secrets to
+//! these), so local runs and fork PRs stay green.
+
+mod common;
+
+use common::{env_or_skip, spawn_pipo, unique_tmp, write_config};
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn discord_connect_creates_webhook() {
+    let vars = match env_or_skip(&[
+        "PIPO_IT_DISCORD_TOKEN",
+        "PIPO_IT_DISCORD_GUILD_ID",
+        "PIPO_IT_DISCORD_CHANNEL_ID",
+    ]) {
+        Some(v) => v,
+        None => return,
+    };
+    let (token, guild_id, channel_id) = (&vars[0], &vars[1], &vars[2]);
+
+    // channel_mapping key must be a numeric channel-id string; guild_id is a number.
+    let config_json = format!(
+        r#"{{
+  "buses": [{{ "id": "main" }}],
+  "transports": [
+    {{ "transport": "Discord", "token": "{token}", "guild_id": {guild_id},
+       "channel_mapping": {{ "{channel_id}": "main" }} }}
+  ]
+}}"#
+    );
+    let config = write_config(&config_json);
+    let db = unique_tmp("db.sqlite3");
+    let mut pipo = spawn_pipo(&config, &db);
+
+    let http = reqwest::Client::new();
+    let url = format!("https://discord.com/api/v10/channels/{channel_id}/webhooks");
+    let expected = format!("PIPO {channel_id}");
+
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut found = false;
+    while Instant::now() < deadline {
+        if let Ok(resp) = http
+            .get(&url)
+            .header("Authorization", format!("Bot {token}"))
+            .send()
+            .await
+        {
+            if let Ok(body) = resp.text().await {
+                if body.contains(&expected) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    let running = pipo.is_running();
+    assert!(
+        found,
+        "expected pipo to create the Discord webhook '{expected}' \
+         (pipo still running: {running}); pipo stderr:\n{}",
+        pipo.stderr()
+    );
+}

--- a/tests/irc_bridge.rs
+++ b/tests/irc_bridge.rs
@@ -1,0 +1,110 @@
+//! Live IRC bridging test. Stands up nothing itself — the workflow provides a
+//! bare ircd (a GitHub Actions service container) and sets `PIPO_IT_IRC_SERVER`
+//! to its `host:port`. The test self-skips when that env var is absent, so a
+//! plain `cargo test` (locally / on fork PRs) stays green.
+//!
+//! Topology: one pipo process with TWO IRC transports on a single bus. Two
+//! transports are required because every outbound handler skips messages it
+//! originated (`sender == self.transport_id`), so a single transport cannot
+//! bridge its own channels. An independent `irc`-crate client posts into
+//! transport A's channel and asserts pipo relays it into transport B's channel
+//! as a CTCP ACTION of the form `<I!nick> message`.
+
+mod common;
+
+use common::{spawn_pipo, unique_tmp, write_config};
+
+use futures::StreamExt;
+use irc::client::prelude::{Client, Command, Config};
+use std::time::Duration;
+use tokio::time::{timeout, Instant};
+
+/// Parse `host:port` (plaintext) from the `PIPO_IT_IRC_SERVER` value.
+fn parse_server(server: &str) -> (String, u16) {
+    match server.rsplit_once(':') {
+        Some((host, port)) => (host.to_string(), port.parse().unwrap_or(6667)),
+        None => (server.to_string(), 6667),
+    }
+}
+
+#[tokio::test]
+async fn bridges_message_between_two_irc_channels() {
+    let server = match std::env::var("PIPO_IT_IRC_SERVER") {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            eprintln!("SKIP: PIPO_IT_IRC_SERVER is not set; skipping IRC bridge test");
+            return;
+        }
+    };
+
+    // pipo: two IRC transports, one bus, plaintext, distinct nicks.
+    let config_json = format!(
+        r##"{{
+  "buses": [{{ "id": "main" }}],
+  "transports": [
+    {{ "transport": "IRC", "nickname": "pipo-a", "server": "{server}", "use_tls": false,
+       "img_root": "images", "channel_mapping": {{ "#pipo-a": "main" }} }},
+    {{ "transport": "IRC", "nickname": "pipo-b", "server": "{server}", "use_tls": false,
+       "img_root": "images", "channel_mapping": {{ "#pipo-b": "main" }} }}
+  ]
+}}"##
+    );
+    let config = write_config(&config_json);
+    let db = unique_tmp("db.sqlite3");
+    let mut pipo = spawn_pipo(&config, &db);
+
+    // Independent observer/injector client that joins both channels.
+    let (host, port) = parse_server(&server);
+    let client_config = Config {
+        nickname: Some("tester".to_string()),
+        server: Some(host),
+        port: Some(port),
+        use_tls: Some(false),
+        channels: vec!["#pipo-a".to_string(), "#pipo-b".to_string()],
+        ..Config::default()
+    };
+    let mut client = Client::from_config(client_config)
+        .await
+        .expect("failed to build test IRC client");
+    client.identify().expect("failed to identify test IRC client");
+    let mut stream = client.stream().expect("failed to open test IRC stream");
+
+    let marker = format!("bridge-marker-{}", std::process::id());
+
+    // Resend the stimulus periodically to tolerate pipo's connect/join latency,
+    // and watch #pipo-b for the relayed CTCP ACTION.
+    let found = timeout(Duration::from_secs(60), async {
+        let mut last_send = Instant::now() - Duration::from_secs(10);
+        loop {
+            if last_send.elapsed() >= Duration::from_secs(3) {
+                let _ = client.send_privmsg("#pipo-a", &marker);
+                last_send = Instant::now();
+            }
+            // Poll with a short timeout so the resend loop keeps ticking and the
+            // client's outgoing queue gets flushed.
+            match timeout(Duration::from_secs(1), stream.next()).await {
+                Ok(Some(Ok(message))) => {
+                    if let Command::PRIVMSG(target, content) = &message.command {
+                        if target == "#pipo-b"
+                            && content.contains(&marker)
+                            && content.contains("tester")
+                        {
+                            return true;
+                        }
+                    }
+                }
+                Ok(Some(Err(_))) | Ok(None) => return false, // stream error/end
+                Err(_) => {}                                  // 1s read timeout
+            }
+        }
+    })
+    .await;
+
+    let running = pipo.is_running();
+    assert!(
+        matches!(found, Ok(true)),
+        "expected the message posted to #pipo-a to be bridged to #pipo-b \
+         (pipo still running: {running}); pipo stderr:\n{}",
+        pipo.stderr()
+    );
+}

--- a/tests/slack_smoke.rs
+++ b/tests/slack_smoke.rs
@@ -1,0 +1,54 @@
+//! Live Slack connect smoke test.
+//!
+//! As with Discord, pipo drops bot-authored inbound messages, so a real bridge
+//! assertion would need a user token. Instead we assert the connection path: on
+//! valid tokens pipo completes `apps.connections.open` (app-level token) plus
+//! `conversations.list` (bot token) and then stays in the Socket Mode read loop
+//! indefinitely; with bad tokens/scopes the sole transport task errors out and
+//! the process exits. So "still running after a warm-up window" is a meaningful
+//! success signal.
+//!
+//! Self-skips unless `PIPO_IT_SLACK_APP_TOKEN`, `PIPO_IT_SLACK_BOT_TOKEN` and
+//! `PIPO_IT_SLACK_CHANNEL` are all set.
+
+mod common;
+
+use common::{env_or_skip, spawn_pipo, unique_tmp, write_config};
+use std::time::Duration;
+
+#[tokio::test]
+async fn slack_connect_stays_alive() {
+    let vars = match env_or_skip(&[
+        "PIPO_IT_SLACK_APP_TOKEN",
+        "PIPO_IT_SLACK_BOT_TOKEN",
+        "PIPO_IT_SLACK_CHANNEL",
+    ]) {
+        Some(v) => v,
+        None => return,
+    };
+    let (app_token, bot_token, channel) = (&vars[0], &vars[1], &vars[2]);
+
+    // channel_mapping key is the "#channel-name" form Slack uses internally.
+    let config_json = format!(
+        r#"{{
+  "buses": [{{ "id": "main" }}],
+  "transports": [
+    {{ "transport": "Slack", "token": "{app_token}", "bot_token": "{bot_token}",
+       "channel_mapping": {{ "{channel}": "main" }} }}
+  ]
+}}"#
+    );
+    let config = write_config(&config_json);
+    let db = unique_tmp("db.sqlite3");
+    let mut pipo = spawn_pipo(&config, &db);
+
+    // Give pipo time to open the socket and enumerate channels.
+    tokio::time::sleep(Duration::from_secs(20)).await;
+
+    assert!(
+        pipo.is_running(),
+        "pipo exited during Slack connect (likely an auth/scope failure); \
+         pipo stderr:\n{}",
+        pipo.stderr()
+    );
+}

--- a/tests/startup.rs
+++ b/tests/startup.rs
@@ -1,0 +1,91 @@
+//! Always-on integration tests that exercise pipo's real startup path end to
+//! end through the binary: argument/env parsing, config file read + comment
+//! stripping, JSON deserialization, sqlite pool creation, schema bootstrap and
+//! the bus/transport wiring loop. These need no external services.
+
+mod common;
+
+use common::{run_pipo_to_completion, unique_tmp, write_config};
+use rusqlite::Connection;
+
+const EMPTY_CONFIG: &str = r#"{"buses":[{"id":"main"}],"transports":[]}"#;
+
+fn messages_table_exists(db: &std::path::Path) -> bool {
+    let conn = Connection::open(db).expect("failed to open sqlite db");
+    let count: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='messages'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("failed to query sqlite_master");
+    count >= 1
+}
+
+#[test]
+fn usage_printed_when_args_missing() {
+    let out = run_pipo_to_completion(&[], &[]);
+    assert!(out.status.success(), "pipo should exit successfully with no args");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Usage:"),
+        "expected a usage message on stdout, got: {stdout}"
+    );
+}
+
+#[test]
+fn empty_transports_config_bootstraps_messages_table() {
+    let config = write_config(EMPTY_CONFIG);
+    let db = unique_tmp("db.sqlite3");
+    let out = run_pipo_to_completion(
+        &[config.to_str().unwrap(), db.to_str().unwrap()],
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "pipo should exit cleanly for a no-transport config; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        messages_table_exists(&db),
+        "pipo should have created the `messages` table during startup"
+    );
+}
+
+#[test]
+fn config_and_db_read_from_env_vars() {
+    let config = write_config(EMPTY_CONFIG);
+    let db = unique_tmp("db.sqlite3");
+    let out = run_pipo_to_completion(
+        &[],
+        &[
+            ("CONFIG_PATH", config.to_str().unwrap()),
+            ("DB_PATH", db.to_str().unwrap()),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "pipo should honor CONFIG_PATH/DB_PATH env vars; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        messages_table_exists(&db),
+        "pipo should have created the `messages` table via env-var config"
+    );
+}
+
+#[test]
+fn invalid_config_json_reports_parse_error() {
+    let config = write_config("this is definitely not json");
+    let db = unique_tmp("db.sqlite3");
+    let out = run_pipo_to_completion(
+        &[config.to_str().unwrap(), db.to_str().unwrap()],
+        &[],
+    );
+    // pipo's main swallows the error and still exits 0, so assert on stderr.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Couldn't parse the JSON"),
+        "expected a config parse error on stderr, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Add a `tests/` integration-test harness plus a dedicated GitHub Actions
workflow that exercises pipo end to end, going beyond the inline unit
tests that build.yml already runs.

Because pipo's internals (the Message enum, config types, buses) are
private, the tests drive the system through the compiled binary
(CARGO_BIN_EXE_pipo) with real temp config + sqlite files.

- tests/startup.rs: always-on tests of the real inner_main startup path
  (usage output, empty-transport config bootstrapping the sqlite schema,
  CONFIG_PATH/DB_PATH env vars, and config parse-error reporting).
- tests/irc_bridge.rs: credential-free live bridging test. Runs pipo with
  two IRC transports on one bus against a bare ircd and verifies relay
  with an independent irc-crate client. Self-skips without
  PIPO_IT_IRC_SERVER.
- tests/discord_smoke.rs, tests/slack_smoke.rs: live connect/startup
  smokes gated on secrets; self-skip when absent (so fork PRs and local
  runs stay green).
- tests/common/mod.rs: shared helpers (temp paths, config writer,
  kill-on-drop process guard, env gating).
- .github/workflows/integration.yml: startup-and-irc job (ircd service
  container) and live-service-smoke job (secrets mapped to env). The
  existing build.yml is left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VQWzBvQdn8qLzZqdZynnfj