### PR TITLE
Add systemd + netns egress gating for blue-green cutover

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,106 @@
+# Blue/green egress gating (systemd + network namespaces)
+
+No containers: blue and green each run as a systemd service inside their
+own network namespace, with no default internet route of their own. All
+egress passes through the host, which NATs and gates traffic for whichever
+color is currently "active" via nftables. This exists to solve one
+problem: Discord/Slack/IRC/Mumble connections are long-lived and stateful,
+so a naive blue-green switch can leave both colors connected and relaying
+every message twice. Only the active color's traffic is ever allowed out.
+
+## Layout
+
+- `scripts/netns-setup.sh` — creates/destroys a color's netns + veth pair.
+  Called by `systemd/pipo-netns-setup@.service`.
+- `systemd/pipo-netns-setup@.service` — templated oneshot unit, instantiate
+  as `@blue` / `@green`.
+- `systemd/pipo@.service` — templated unit for the pipo binary itself,
+  joins the matching namespace via `NetworkNamespacePath=`. Instantiate as
+  `@blue` / `@green`. Requires systemd >= 245.
+- `nftables/pipo-gateway.nft` — host-side ruleset: masquerades and forwards
+  only the active color's subnet, drops the other.
+- `scripts/promote.sh <blue|green>` — flips the active color and forcibly
+  evicts the demoted color's conntrack entries so its sockets die
+  immediately.
+
+## Prerequisites
+
+- Linux host with `nftables`, `conntrack-tools`, and `iproute2` installed.
+- `net.ipv4.ip_forward=1` set on the host.
+- systemd >= 245 (for `NetworkNamespacePath=`).
+
+## Install
+
+```
+install -Dm755 deploy/scripts/netns-setup.sh /opt/pipo/deploy/scripts/netns-setup.sh
+install -Dm755 deploy/scripts/promote.sh /opt/pipo/deploy/scripts/promote.sh
+install -Dm644 deploy/systemd/pipo-netns-setup@.service /etc/systemd/system/pipo-netns-setup@.service
+install -Dm644 deploy/systemd/pipo@.service /etc/systemd/system/pipo@.service
+install -Dm644 deploy/nftables/pipo-gateway.nft /opt/pipo/deploy/nftables/pipo-gateway.nft
+```
+
+Add to `/etc/nftables.conf`:
+
+```
+include "/opt/pipo/deploy/nftables/pipo-gateway.nft"
+```
+
+then `systemctl reload nftables`.
+
+Create per-color config, e.g. `/etc/pipo/blue.env`:
+
+```
+CONFIG_PATH=/etc/pipo/blue-config.json
+DB_PATH=/var/lib/pipo/blue/pipo.sqlite
+```
+
+and `/etc/pipo/green.env` pointing at `green-config.json` /
+`/var/lib/pipo/green/pipo.sqlite`. `StateDirectory=pipo/%i` in
+`pipo@.service` creates and owns `/var/lib/pipo/<color>` for the
+service's dynamic user.
+
+`systemctl daemon-reload` after installing units.
+
+## Runbook
+
+Start blue and promote it (nothing is active by default — the nftables
+set starts empty, so neither color can reach the internet until you run
+`promote.sh` at least once):
+
+```
+systemctl start pipo-netns-setup@blue pipo@blue
+/opt/pipo/deploy/scripts/promote.sh blue
+```
+
+Deploy green alongside it (still gated closed):
+
+```
+systemctl start pipo-netns-setup@green pipo@green
+journalctl -u pipo@green -f   # confirm it starts and is waiting/backing off, not crash-looping
+```
+
+Cut over:
+
+```
+/opt/pipo/deploy/scripts/promote.sh green
+journalctl -u pipo@green -f   # confirm it connects to Discord/Slack/IRC/Mumble
+journalctl -u pipo@blue -f    # confirm its connections were dropped and it's backing off cleanly
+```
+
+Decommission blue once green is confirmed healthy:
+
+```
+systemctl stop pipo@blue pipo-netns-setup@blue
+```
+
+Rollback (before decommissioning blue) is symmetric: `promote.sh blue`.
+
+## Notes
+
+- Gating happens at L3/L4 (source subnet), so it applies uniformly to
+  HTTP, WebSocket, and raw TCP+TLS traffic (Mumble, IRC) with no
+  protocol-specific proxy logic and no changes to pipo's own client code.
+- Per-request authorization (Slack HMAC verification, Discord/Slack bearer
+  tokens, Mumble TLS certs) is unaffected — it stays inside pipo's own
+  client code exactly as today. The gateway only ever makes a yes/no
+  decision based on which subnet a packet came from.

--- a/deploy/nftables/pipo-gateway.nft
+++ b/deploy/nftables/pipo-gateway.nft
@@ -1,0 +1,30 @@
+#!/usr/sbin/nft -f
+# Gateway ruleset for pipo blue/green egress gating.
+#
+# Only the color whose /30 is in `active_subnet` may reach the internet;
+# the other color's forwarded traffic is dropped. deploy/scripts/promote.sh
+# is the only thing that should mutate `active_subnet` at runtime.
+#
+# Include this from /etc/nftables.conf, e.g.:
+#   include "/opt/pipo/deploy/nftables/pipo-gateway.nft"
+
+table inet pipo_gateway {
+    set active_subnet {
+        type ipv4_addr
+        flags interval
+        # Empty by default: neither color may egress until promote.sh
+        # has been run at least once.
+    }
+
+    chain forward {
+        type filter hook forward priority filter; policy accept;
+
+        ip saddr { 10.200.1.0/30, 10.200.2.0/30 } ip saddr != @active_subnet drop
+    }
+
+    chain postrouting {
+        type nat hook postrouting priority srcnat; policy accept;
+
+        ip saddr @active_subnet masquerade
+    }
+}

--- a/deploy/scripts/netns-setup.sh
+++ b/deploy/scripts/netns-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Create/destroy the network namespace + veth pair for one pipo color.
+# Invoked by pipo-netns-setup@<color>.service (ExecStart=up, ExecStop=down).
+set -euo pipefail
+
+ACTION="${1:?usage: netns-setup.sh <up|down> <blue|green>}"
+COLOR="${2:?usage: netns-setup.sh <up|down> <blue|green>}"
+
+case "$COLOR" in
+  blue)  ID=1 ;;
+  green) ID=2 ;;
+  *) echo "unknown color: $COLOR (expected blue or green)" >&2; exit 1 ;;
+esac
+
+NETNS="pipo-${COLOR}"
+VETH_HOST="veth-${COLOR}-h"
+VETH_NS="veth-${COLOR}-n"
+HOST_ADDR="10.200.${ID}.1/30"
+NS_ADDR="10.200.${ID}.2/30"
+NS_GW="10.200.${ID}.1"
+
+up() {
+  ip netns add "$NETNS"
+
+  ip link add "$VETH_HOST" type veth peer name "$VETH_NS"
+  ip link set "$VETH_NS" netns "$NETNS"
+
+  ip addr add "$HOST_ADDR" dev "$VETH_HOST"
+  ip link set "$VETH_HOST" up
+
+  ip netns exec "$NETNS" ip addr add "$NS_ADDR" dev "$VETH_NS"
+  ip netns exec "$NETNS" ip link set "$VETH_NS" up
+  ip netns exec "$NETNS" ip link set lo up
+  ip netns exec "$NETNS" ip route add default via "$NS_GW"
+
+  # Allow the host to forward/NAT traffic arriving on this veth.
+  sysctl -qw "net.ipv4.conf.${VETH_HOST}.forwarding=1"
+}
+
+down() {
+  # Deleting either end of a veth pair removes both ends.
+  ip link del "$VETH_HOST" 2>/dev/null || true
+  ip netns del "$NETNS" 2>/dev/null || true
+}
+
+case "$ACTION" in
+  up)   up ;;
+  down) down ;;
+  *) echo "unknown action: $ACTION (expected up or down)" >&2; exit 1 ;;
+esac

--- a/deploy/scripts/promote.sh
+++ b/deploy/scripts/promote.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Flip which color's egress is live and forcibly drop the demoted color's
+# established connections, so blue and green are never both relaying at once.
+set -euo pipefail
+
+COLOR="${1:?usage: promote.sh <blue|green>}"
+
+case "$COLOR" in
+  blue)  SUBNET=10.200.1.0/30; DEMOTED_SUBNET=10.200.2.0/30; DEMOTED_ADDR=10.200.2.2 ;;
+  green) SUBNET=10.200.2.0/30; DEMOTED_SUBNET=10.200.1.0/30; DEMOTED_ADDR=10.200.1.2 ;;
+  *) echo "unknown color: $COLOR (expected blue or green)" >&2; exit 1 ;;
+esac
+
+nft flush set inet pipo_gateway active_subnet
+nft add element inet pipo_gateway active_subnet "{ $SUBNET }"
+
+# Evict the demoted color's tracked connections in both directions so its
+# sockets die immediately instead of lingering until a keepalive fails.
+conntrack -D -s "$DEMOTED_ADDR" >/dev/null 2>&1 || true
+conntrack -D -d "$DEMOTED_ADDR" >/dev/null 2>&1 || true
+
+mkdir -p /run/pipo
+printf '%s' "$COLOR" > /run/pipo/active-color
+
+echo "promoted $COLOR; flushed conntrack entries for demoted subnet $DEMOTED_SUBNET"

--- a/deploy/systemd/pipo-netns-setup@.service
+++ b/deploy/systemd/pipo-netns-setup@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Network namespace + veth pair for pipo (%i)
+Before=pipo@%i.service
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/opt/pipo/deploy/scripts/netns-setup.sh up %i
+ExecStop=/opt/pipo/deploy/scripts/netns-setup.sh down %i
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/pipo@.service
+++ b/deploy/systemd/pipo@.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=pipo chat relay (%i)
+Requires=pipo-netns-setup@%i.service
+After=pipo-netns-setup@%i.service network-online.target
+PartOf=pipo-netns-setup@%i.service
+
+[Service]
+Type=simple
+NetworkNamespacePath=/run/netns/pipo-%i
+
+DynamicUser=yes
+StateDirectory=pipo/%i
+EnvironmentFile=/etc/pipo/%i.env
+ExecStart=/usr/local/bin/pipo
+Restart=on-failure
+RestartSec=5
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
pipo has no inbound server surface worth fronting; its risk is Discord
gateway, Slack Socket Mode, IRC, and Mumble connections staying live in
both colors at once and relaying every message twice during a deploy.
This adds a network-namespace-per-color layer (no containers) with a
host-side nftables gate that only lets the active color's traffic
through, plus a promote script that flips the gate and force-drops the
demoted color's conntrack entries so its sockets die immediately.